### PR TITLE
Use Codex for article generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,10 @@ TWITTER_ACCESS_SECRET=
 # Cloudflare (for wrangler)
 CLOUDFLARE_ACCOUNT_ID=
 CLOUDFLARE_API_TOKEN=
+
+# Article generation
+# Defaults to Codex CLI with the local ChatGPT/Codex login.
+ARTICLE_GENERATOR=codex
+CODEX_CLI=
+# Optional rollback path: set ARTICLE_GENERATOR=claude and CLAUDE_CLI if needed.
+CLAUDE_CLI=

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          direct_prompt: |
+          prompt: |
             Review this PR. Check for:
             1. TypeScript errors or type issues
             2. Security vulnerabilities (XSS, injection, etc.)
@@ -41,14 +41,13 @@ jobs:
             If everything looks good:
             - Approve the PR with a short summary
           use_bedrock: false
-          timeout_minutes: 10
 
       - name: Auto-merge if approved
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Check if the PR has an approving review from claude
-          APPROVED=$(gh pr reviews ${{ github.event.pull_request.number }} --json state --jq '[.[] | select(.state == "APPROVED")] | length')
+          # `gh pr reviews --json` is not available on all hosted runner gh versions.
+          APPROVED=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --jq '[.[] | select(.state == "APPROVED")] | length')
           if [ "$APPROVED" -gt "0" ]; then
             gh pr merge ${{ github.event.pull_request.number }} --squash --auto
             echo "PR auto-merge enabled"

--- a/blog/src/components/PostCard.astro
+++ b/blog/src/components/PostCard.astro
@@ -36,7 +36,7 @@ const formattedDate = date.toLocaleDateString('tr-TR', { year: 'numeric', month:
             <span class="tag">{tag}</span>
           ))}
         </div>
-        <span class="ai-badge" title="Bu içerik Claude AI kullanılarak çevrilmiştir">AI Çeviri</span>
+        <span class="ai-badge" title="Bu içerik AI destekli çeviri ve özet olarak hazırlanmıştır">AI Çeviri</span>
       </div>
     </div>
   </a>

--- a/blog/src/content/posts/analist-trump-i-rani-bombalarken-petrolunu-serbest-birakiyor-tirmanma-merdiveni-uyarisi.md
+++ b/blog/src/content/posts/analist-trump-i-rani-bombalarken-petrolunu-serbest-birakiyor-tirmanma-merdiveni-uyarisi.md
@@ -1,24 +1,17 @@
 ---
-title: "**
-Analist: 'Trump İran'ı Bombalarken Petrolünü Serbest Bırakıyor — Tırmanma Merdiveni Uyarısı'
-
----
-
-**"
+title: "Analist: 'Trump İran'ı Bombalarken Petrolünü Serbest Bırakıyor — Tırmanma Merdiveni Uyarısı'"
 date: 2026-03-31
 source: "https://www.youtube.com/watch?v=LHIH6xVIJEU"
 channel: "Glenn Diesen"
 videoId: "LHIH6xVIJEU"
-description: "** Bu podcast bölümünde bir analist, Başkan Trump'ın İran'a yönelik askeri operasyonları sürdürürken aynı anda küresel petrol piyasasını dengeleme zorunluluğunu değerlendirdi. Konuşmacı, Trump'ın uluslararası ekonomide bir felaketi önlemek için küres"
-tags: ["**\nABD-İran ilişkileri","petrol piyasası","Hürmüz Boğazı","Trump","Rusya yaptırımları","askeri tırmanma","küresel ekonomi"]
-guests: ["**\nYok (konuşmacı transkriptte tanımlanmamış)"]
+description: "Bu podcast bölümünde bir analist, Başkan Trump'ın İran'a yönelik askeri operasyonları sürdürürken aynı anda küresel petrol piyasasını dengeleme zorunluluğunu değerlendirdi."
+tags: ["ABD-İran ilişkileri","petrol piyasası","Hürmüz Boğazı","Trump","Rusya yaptırımları","askeri tırmanma","küresel ekonomi"]
+guests: ["Yok (konuşmacı transkriptte tanımlanmamış)"]
 category: "siyaset"
 readingTime:
   summary: 1
   full: 1
 ---
-
-**
 
 ## Trump'ın İran Stratejisi: Bombalama ve Petrol Dengesi
 

--- a/blog/src/content/posts/askeri-analist-trump-i-rana-kara-operasyonu-baslatmak-i-stiyor-harg-adasi-ve-nukleer-tesisler-hedefte.md
+++ b/blog/src/content/posts/askeri-analist-trump-i-rana-kara-operasyonu-baslatmak-i-stiyor-harg-adasi-ve-nukleer-tesisler-hedefte.md
@@ -1,7 +1,5 @@
 ---
-title: "Askeri Analist: 'Trump İran'a Kara Operasyonu Başlatmak İstiyor — Harg Adası ve Nükleer Tesisler Hedefte'
-
----"
+title: "Askeri Analist: 'Trump İran'a Kara Operasyonu Başlatmak İstiyor — Harg Adası ve Nükleer Tesisler Hedefte'"
 date: 2026-04-13
 source: "https://www.youtube.com/watch?v=sJOaZQ3T4EA"
 channel: "Glenn Diesen"

--- a/blog/src/content/posts/hristiyan-siyonizm-analizi-stratejik-hedefleri-kuresel-armageddon-nukleer-silahlara-sahip-apokaliptik-bir-hareket.md
+++ b/blog/src/content/posts/hristiyan-siyonizm-analizi-stratejik-hedefleri-kuresel-armageddon-nukleer-silahlara-sahip-apokaliptik-bir-hareket.md
@@ -1,25 +1,17 @@
 ---
-title: "**
-
-Hristiyan Siyonizm Analizi: 'Stratejik Hedefleri Küresel Armageddon — Nükleer Silahlara Sahip Apokaliptik Bir Hareket'
-
----
-
-**"
+title: "Hristiyan Siyonizm Analizi: 'Stratejik Hedefleri Küresel Armageddon — Nükleer Silahlara Sahip Apokaliptik Bir Hareket'"
 date: 2026-04-10
 source: "https://www.youtube.com/watch?v=vmPBKZCNsF8"
 channel: "The Thinking Muslim"
 videoId: "vmPBKZCNsF8"
 description: "Bir podcast yayınında bir konuşmacı, Hristiyan Siyonistlerin ideolojik yapısını ve küresel güvenlik açısından oluşturduğu tehdidi değerlendirdi. Konuşmacı, bu hareketin stratejik hedefinin kelimenin tam anlamıyla 'dünyanın sonu' olduğunu savunarak, n"
-tags: ["**"]
-guests: ["**"]
+tags: ["Hristiyan Siyonizm","Armageddon","İsrail","nükleer silahlar","apokaliptik hareket"]
+guests: ["Yok (konuşmacı transkriptte tanımlanmamış)"]
 category: "siyaset"
 readingTime:
   summary: 1
   full: 1
 ---
-
-**
 
 ## Hristiyan Siyonistlerin Kıyamet Stratejisi ve Küresel Tehlike
 

--- a/blog/src/content/posts/konusmaci-abd-i-ranin-egemenligini-kabul-etmiyor-muzakereler-bir-i-stihbarat-manevrasiydi-i-ran-yine-de-dunyaya-cozum-aradigini-gosterdi.md
+++ b/blog/src/content/posts/konusmaci-abd-i-ranin-egemenligini-kabul-etmiyor-muzakereler-bir-i-stihbarat-manevrasiydi-i-ran-yine-de-dunyaya-cozum-aradigini-gosterdi.md
@@ -1,25 +1,17 @@
 ---
-title: "**
-
-Konuşmacı: 'ABD İran'ın Egemenliğini Kabul Etmiyor — Müzakereler Bir İstihbarat Manevrasıydı, İran Yine de Dünyaya Çözüm Aradığını Gösterdi'
-
----
-
-**"
+title: "Konuşmacı: 'ABD İran'ın Egemenliğini Kabul Etmiyor — Müzakereler Bir İstihbarat Manevrasıydı, İran Yine de Dünyaya Çözüm Aradığını Gösterdi'"
 date: 2026-04-13
 source: "https://www.youtube.com/watch?v=tBmPSH39s2s"
 channel: "Glenn Diesen"
 videoId: "tBmPSH39s2s"
 description: "Glenn Diesen'in YouTube kanalına konuk olan İran heyeti üyesi S. Muhammad Mandi, İslamabad'da ABD ile İran arasında yürütülen müzakerelerin perde arkasını anlattı."
-tags: ["**"]
-guests: ["**"]
+tags: ["ABD-İran ilişkileri","müzakereler","İran egemenliği","Hürmüz Boğazı","diplomasi"]
+guests: ["S. Muhammad Mandi"]
 category: "siyaset"
 readingTime:
   summary: 1
   full: 1
 ---
-
-**
 
 # İslamabad Müzakerelerinin Perde Arkası: Mandi, "ABD İran'ın Egemenliğini Kabul Etmiyor" Dedi
 

--- a/blog/src/content/posts/konusmaci-starmer-i-cikarmaya-calisiyorlar-ama-yerine-koyabilecekleri-kimse-yok-avrupali-siyasetciler-rusya-ve-ukrayna-takintisindan-vazgecmiyor.md
+++ b/blog/src/content/posts/konusmaci-starmer-i-cikarmaya-calisiyorlar-ama-yerine-koyabilecekleri-kimse-yok-avrupali-siyasetciler-rusya-ve-ukrayna-takintisindan-vazgecmiyor.md
@@ -1,9 +1,9 @@
 ---
 title: "Konuşmacı: 'Starmer'ı Çıkarmaya Çalışıyorlar Ama Yerine Koyabilecekleri Kimse Yok — Avrupalı Siyasetçiler Rusya ve Ukrayna Takıntısından Vazgeçmiyor'"
 date: 2026-05-16
-source: ""
-channel: ""
-videoId: ""
+source: "https://www.youtube.com/watch?v=Wjb4vFK37t0"
+channel: "Glenn Diesen"
+videoId: "Wjb4vFK37t0"
 description: "Bir podcast yayınında konuşan analist, Avrupa siyasi elitlerinin Rusya'ya karşı yeniden silahlanma ve Ukrayna'ya destek konularına odaklandığını, İngiltere Başbakanı Keir Starmer'ın iktidarının sonuna yaklaştığını ancak yerleşik düzenin onun yerine sadece 'biraz daha popüler' birini aradığını ve bu nedenle krizin çözümsüz hale geldiğini değerlendirdi."
 tags: ["Avrupa siyaseti","Keir Starmer","Rusya","Ukrayna savaşı","yeniden silahlanma","İngiltere","Mette Frederiksen","Hollanda","Polonya","Danimarka","siyasi elit","dış politika"]
 guests: ["Keir Starmer","Mette Frederiksen"]

--- a/blog/src/content/posts/musluman-toplumda-basari-krizi-cocugunuzu-hz-peygamberin-yanina-goturup-i-ste-basari-diyemezsiniz-basariyi-porsche-ile-olcuyoruz.md
+++ b/blog/src/content/posts/musluman-toplumda-basari-krizi-cocugunuzu-hz-peygamberin-yanina-goturup-i-ste-basari-diyemezsiniz-basariyi-porsche-ile-olcuyoruz.md
@@ -1,25 +1,17 @@
 ---
-title: "**
-
-Müslüman Toplumda Başarı Krizi: 'Çocuğunuzu Hz. Peygamber'in Yanına Götürüp 'İşte Başarı' Diyemezsiniz — Başarıyı Porsche ile Ölçüyoruz'
-
----
-
-**"
+title: "Müslüman Toplumda Başarı Krizi: 'Çocuğunuzu Hz. Peygamber'in Yanına Götürüp 'İşte Başarı' Diyemezsiniz — Başarıyı Porsche ile Ölçüyoruz'"
 date: 2026-03-31
 source: "https://www.youtube.com/watch?v=Mm0o_UX3LzQ"
 channel: "The Thinking Muslim"
 videoId: "Mm0o_UX3LzQ"
 description: "Bir podcast yayınında iki konuşmacı, günümüz Müslümanlarının başarı tanımı üzerine dikkat çekici bir tartışma yürüttü. Konuşmanın merkezinde, İslam'ın bugün Müslümanlar için neden 'sorunlu' hale geldiği ve maddi zenginliğin başarının tek ölçütü olara"
-tags: ["**"]
-guests: ["**"]
+tags: ["Müslüman toplum","başarı","İslam","maddi zenginlik","Peygamber modeli"]
+guests: ["Yok (konuşmacılar transkriptte tanımlanmamış)"]
 category: "siyaset"
 readingTime:
   summary: 1
   full: 1
 ---
-
-**
 
 ## Müslümanlar İçin Başarı Tanımı: Maddi Zenginlik mi, Peygamber Modeli mi?
 

--- a/blog/src/content/posts/orta-dogu-analisti-trump-anlasma-yapabilir-ama-once-i-srail-dizginlenmeli-i-srail-trumpin-vurmayin-dedigi-hedefleri-saatler-i-cinde-bombaliyor.md
+++ b/blog/src/content/posts/orta-dogu-analisti-trump-anlasma-yapabilir-ama-once-i-srail-dizginlenmeli-i-srail-trumpin-vurmayin-dedigi-hedefleri-saatler-i-cinde-bombaliyor.md
@@ -1,25 +1,17 @@
 ---
-title: "**
-
-Orta Doğu Analisti: 'Trump Anlaşma Yapabilir Ama Önce İsrail Dizginlenmeli — İsrail, Trump'ın Vurmayın Dediği Hedefleri Saatler İçinde Bombalıyor'
-
----
-
-**"
+title: "Orta Doğu Analisti: 'Trump Anlaşma Yapabilir Ama Önce İsrail Dizginlenmeli — İsrail, Trump'ın Vurmayın Dediği Hedefleri Saatler İçinde Bombalıyor'"
 date: 2026-04-09
 source: "https://www.youtube.com/watch?v=5b_8_CLVVng"
 channel: "Glenn Diesen"
 videoId: "5b_8_CLVVng"
 description: "Bir podcast yayınında konuşan analist, ABD Başkanı Trump'ın Orta Doğu'da sürdürülebilir bir anlaşma arayışını, İsrail'in bu çabaları sistematik olarak baltaladığını ve bölgedeki diplomatik dengeleri değerlendirdi. Konuşmacı, Trump'ın temel hedefini ş"
-tags: ["**"]
-guests: ["**"]
+tags: ["Orta Doğu","Trump","İsrail","diplomasi","Körfez"]
+guests: ["Yok (konuşmacı transkriptte tanımlanmamış)"]
 category: "siyaset"
 readingTime:
   summary: 1
   full: 1
 ---
-
-**
 
 ## Trump, İsrail ve Körfez'de Sürdürülebilir Anlaşma Arayışı
 

--- a/blog/src/pages/hakkinda.astro
+++ b/blog/src/pages/hakkinda.astro
@@ -32,7 +32,7 @@ export const prerender = true;
       <ol>
         <li><strong>İzleme:</strong> Belirlenen YouTube kanalları ve playlistler saatlik olarak taranır.</li>
         <li><strong>Transkript:</strong> Video altyazıları otomatik olarak çekilir ve temizlenir.</li>
-        <li><strong>Çeviri:</strong> İçerik, Claude yapay zekâ modeli kullanılarak iki formatta Türkçe'ye çevrilir.</li>
+        <li><strong>Çeviri:</strong> İçerik, Codex destekli yapay zekâ üretimiyle iki formatta Türkçe'ye çevrilir.</li>
         <li><strong>Yayın:</strong> Çevrilen içerik otomatik olarak siteye yayınlanır.</li>
       </ol>
     </section>
@@ -53,7 +53,7 @@ export const prerender = true;
     <section>
       <h2>Çeviri Metodolojisi</h2>
       <p>
-        Çeviriler Anthropic'in Claude yapay zekâ modeli kullanılarak yapılmaktadır. Sistem şu kurallara göre çalışır:
+        Çeviriler Codex destekli yapay zekâ üretimiyle yapılmaktadır. Sistem şu kurallara göre çalışır:
       </p>
       <ul>
         <li>ABD siyasi terminolojisinin yerleşmiş Türkçe karşılıkları kullanılır (örn: Senate → Senato, State Department → Dışişleri Bakanlığı).</li>
@@ -100,7 +100,7 @@ export const prerender = true;
       <p class="tech-note">
         Site <a href="https://astro.build" target="_blank" rel="noopener noreferrer">Astro</a> ile oluşturulmuş,
         <a href="https://workers.cloudflare.com" target="_blank" rel="noopener noreferrer">Cloudflare Workers</a> üzerinde barındırılmaktadır.
-        Çeviriler <a href="https://claude.ai" target="_blank" rel="noopener noreferrer">Claude</a> (Anthropic) ile yapılmaktadır.
+        Çeviriler Codex CLI destekli yapay zekâ üretimiyle yapılmaktadır.
         Kaynak kodu açıktır: <a href="https://github.com/tugrultsg/AmerikaGundemi" target="_blank" rel="noopener noreferrer">GitHub</a>.
       </p>
     </section>

--- a/pipeline/prompts/translate.md
+++ b/pipeline/prompts/translate.md
@@ -1,19 +1,22 @@
-You are a professional journalist and translator covering international politics and news for a Turkish-speaking audience. You will receive a podcast transcript — it may be in English, Arabic, or another language. Identify the source language and translate everything into Turkish. Produce all of the following sections.
+You are a professional journalist and translator covering international politics and news for a Turkish-speaking audience. You will receive a podcast transcript; it may be in English, Arabic, Turkish, or another language. Identify the source language and translate the editorial content into Turkish. Produce all of the following sections.
 
-IMPORTANT: Skip all advertisements, sponsor reads, promotional segments, and product placements. Do not translate or include them in any section. Focus only on the actual editorial content of the podcast.
+IMPORTANT:
+- Return only the requested content sections. Do not include preambles, process notes, file names, or commentary about your work.
+- Skip all advertisements, sponsor reads, promotional segments, product placements, and calls to subscribe. Do not translate or include them in any section.
+- Use correct Turkish characters at all times: ü, ö, ç, ş, ı, ğ, İ.
 
 ---SUMMARY_ARTICLE---
 Write a 1500-2000 word Turkish article faithfully reporting what was discussed in this podcast. Requirements:
 
-- This is journalism, not paraphrase. Report what was said with precision.
+- This is journalism, not loose paraphrase. Report what was said with precision.
 - Include 5-10 direct quotes translated to Turkish, attributed by speaker name. Format: "quote here," diyen [Speaker Name], "continuation if needed" şeklinde açıkladı/belirtti/ekledi.
-- Use varied Turkish attribution verbs: dedi, belirtti, açıkladı, vurguladı, ekledi, savundu, ifade etti, değerlendirdi — not just "dedi" repeatedly.
-- Do NOT editorialize, interpret, or add opinion. Report what they said.
+- Use varied Turkish attribution verbs: dedi, belirtti, açıkladı, vurguladı, ekledi, savundu, ifade etti, değerlendirdi. Do not repeat only "dedi".
+- Do not editorialize, interpret, or add your own opinion. Report what the speakers said.
 - Preserve the substance of arguments and counterarguments. If two speakers disagreed, represent both positions accurately.
 - Where a speaker makes a specific factual claim or cites a number/statistic, include it exactly.
-- Section headers (##) should reflect the actual topics discussed, in order.
-- Opening paragraph: who spoke, what the episode was about, why it matters — in 2-3 sentences.
-- Keep proper nouns in English. Add Turkish explanation in parentheses on first mention if unfamiliar (e.g., "Supreme Court (Yüksek Mahkeme)").
+- Section headers (`##`) should reflect the actual topics discussed, in order.
+- Opening paragraph: who spoke, what the episode was about, and why it matters, in 2-3 sentences.
+- Keep proper nouns in English. Add Turkish explanation in parentheses on first mention if unfamiliar, for example "Supreme Court (Yüksek Mahkeme)".
 - Use established Turkish equivalents for political terms:
   - "Republican Party" → "Cumhuriyetçi Parti"
   - "Democratic Party" → "Demokrat Parti"
@@ -25,12 +28,12 @@ Write a 1500-2000 word Turkish article faithfully reporting what was discussed i
   - "executive order" → "başkanlık kararnamesi"
   - "swing state" → "kararsız eyalet"
   - "primary" → "ön seçim"
-- For idioms, translate the meaning (e.g., "kicked the can down the road" → "sorunu erteledi").
+- For idioms, translate the meaning, for example "kicked the can down the road" → "sorunu erteledi".
 
 ---FULL_TRANSLATION---
-Complete Turkish translation of the entire transcript. Paragraph by paragraph, preserving the full conversational flow. Use the same terminology rules as above. Structure into readable paragraphs with ## section headers where the topic changes.
+Complete Turkish translation of the entire editorial transcript. Paragraph by paragraph, preserving the full conversational flow. Use the same terminology rules as above. Structure into readable paragraphs with `##` section headers where the topic changes.
 
-CRITICAL: Clearly label who is speaking. Start EVERY paragraph with the speaker's name in bold, followed by a colon — even if the same person continues speaking across multiple paragraphs. Every single paragraph must begin with **Speaker Name:**. No exceptions. Example:
+CRITICAL: Clearly label who is speaking. Start every paragraph with the speaker's name in bold, followed by a colon, even if the same person continues speaking across multiple paragraphs. Every paragraph must begin with `**Speaker Name:**`. Example:
 
 **Tucker Carlson:** Bugün çok önemli bir konuğumuz var...
 
@@ -38,16 +41,16 @@ CRITICAL: Clearly label who is speaking. Start EVERY paragraph with the speaker'
 
 **Avraham Burg:** Bir şey daha eklemek istiyorum. Bu mesele çok derin...
 
-Note: The same speaker's name MUST be repeated at the start of each paragraph, even in consecutive paragraphs by the same person. If you cannot identify the exact speaker, use descriptive labels like **Sunucu:** or **Konuk:**. Never leave any paragraph unattributed.
+If you cannot identify the exact speaker, use descriptive labels like `**Sunucu:**` or `**Konuk:**`. Never leave any paragraph unattributed.
 
 ---TITLE---
-A concise, compelling Turkish title for this article (newspaper headline style). ALWAYS include the full name of the main speaker/guest in the title, not just their title or role. Example: "Eski MI6 Yetkilisi Shashank Joshi: ..." not just "Eski MI6 Yetkilisi: ..."
+A concise, compelling Turkish title for this article in newspaper headline style. Always include the full name of the main speaker/guest in the title, not just their title or role. Example: "Eski MI6 Yetkilisi Shashank Joshi: ..." not just "Eski MI6 Yetkilisi: ..."
 
 ---GUESTS---
 Comma-separated list of people who spoke or were prominently discussed, or "Yok".
 
 ---TAGS---
-Comma-separated topic tags in Turkish (e.g., "ABD seçimleri, dış politika, ekonomi").
+Comma-separated topic tags in Turkish, for example "ABD seçimleri, dış politika, ekonomi".
 
 ---THREAD---
-10-15 tweet-sized bullet points (max 270 chars each) summarizing the key takeaways. Include 2-3 direct quote snippets. Written in Turkish. No hashtags (formatter adds those).
+10-15 tweet-sized bullet points, max 270 characters each, summarizing the key takeaways. Include 2-3 direct quote snippets. Written in Turkish. No hashtags; the formatter adds those.

--- a/pipeline/src/formatter.ts
+++ b/pipeline/src/formatter.ts
@@ -1,6 +1,6 @@
 import { existsSync, writeFileSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { updateVideoStatus, getVideoByVideoId } from './db.js';
+import { updateVideoStatus } from './db.js';
 import { logger } from './logger.js';
 import type { Config, TranslationResult } from './types.js';
 

--- a/pipeline/src/index.ts
+++ b/pipeline/src/index.ts
@@ -71,6 +71,17 @@ function printStatus(): void {
   console.log('');
 }
 
+function translationFromVideo(video: VideoRecord): TranslationResult {
+  return {
+    summaryArticle: video.summary_article!,
+    fullTranslation: video.full_translation ?? '',
+    title: video.translated_title!,
+    guests: JSON.parse(video.guests || '[]'),
+    tags: JSON.parse(video.tags || '[]'),
+    thread: JSON.parse(video.thread || '[]'),
+  };
+}
+
 async function processVideo(
   video: VideoRecord,
   config: Config,
@@ -128,14 +139,7 @@ async function processVideo(
 
   // Stage: Format
   if (afterTranslation.status === 'translated') {
-    const translation: TranslationResult = {
-      summaryArticle: afterTranslation.summary_article!,
-      fullTranslation: afterTranslation.full_translation!,
-      title: afterTranslation.translated_title!,
-      guests: JSON.parse(afterTranslation.guests || '[]'),
-      tags: JSON.parse(afterTranslation.tags || '[]'),
-      thread: JSON.parse(afterTranslation.thread || '[]'),
-    };
+    const translation = translationFromVideo(afterTranslation);
 
     if (!dryRun) {
       writeBlogPost(videoId, afterTranslation.channel, translation, config);
@@ -149,14 +153,7 @@ async function processVideo(
 
   // Already formatted or beyond — return current state
   if (afterTranslation.status === 'formatted') {
-    const translation: TranslationResult = {
-      summaryArticle: afterTranslation.summary_article!,
-      fullTranslation: afterTranslation.full_translation!,
-      title: afterTranslation.translated_title!,
-      guests: JSON.parse(afterTranslation.guests || '[]'),
-      tags: JSON.parse(afterTranslation.tags || '[]'),
-      thread: JSON.parse(afterTranslation.thread || '[]'),
-    };
+    const translation = translationFromVideo(afterTranslation);
     return { blogReady: !dryRun, translation };
   }
 
@@ -355,14 +352,7 @@ async function main(): Promise<void> {
 
     // Also include already-formatted videos waiting for publish
     for (const video of formattedVideos) {
-      const translation: TranslationResult = {
-        summaryArticle: video.summary_article!,
-        fullTranslation: video.full_translation!,
-        title: video.translated_title!,
-        guests: JSON.parse(video.guests || '[]'),
-        tags: JSON.parse(video.tags || '[]'),
-        thread: JSON.parse(video.thread || '[]'),
-      };
+      const translation = translationFromVideo(video);
       blogReadyVideos.push({ videoId: video.video_id, translation });
     }
 

--- a/pipeline/src/translator.ts
+++ b/pipeline/src/translator.ts
@@ -1,5 +1,7 @@
 import { spawn } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { resolvePromptPath } from './config.js';
 import { logger } from './logger.js';
 import type { Config, TranslationOutcome, TranslationResult } from './types.js';
@@ -21,13 +23,27 @@ const SUMMARY_ONLY_MARKERS = [
   '---THREAD---',
 ] as const;
 
-function invokeClaude(prompt: string, timeoutMs: number): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+type GeneratorResult = { stdout: string; stderr: string; exitCode: number };
+type ArticleGenerator = 'codex' | 'claude';
+
+function selectedGenerator(): ArticleGenerator {
+  return process.env.ARTICLE_GENERATOR === 'claude' ? 'claude' : 'codex';
+}
+
+function invokeArticleGenerator(prompt: string, timeoutMs: number): Promise<GeneratorResult> {
+  return selectedGenerator() === 'claude'
+    ? invokeClaude(prompt, timeoutMs)
+    : invokeCodex(prompt, timeoutMs);
+}
+
+function invokeClaude(prompt: string, timeoutMs: number): Promise<GeneratorResult> {
   return new Promise((resolve) => {
     const chunks: Buffer[] = [];
     const errChunks: Buffer[] = [];
     let settled = false;
+    const command = process.env.CLAUDE_CLI || 'claude';
 
-    const child = spawn('claude', ['-p', '--output-format', 'text'], {
+    const child = spawn(command, ['-p', '--output-format', 'text'], {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env },
     });
@@ -68,8 +84,83 @@ function invokeClaude(prompt: string, timeoutMs: number): Promise<{ stdout: stri
   });
 }
 
+function invokeCodex(prompt: string, timeoutMs: number): Promise<GeneratorResult> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    const errChunks: Buffer[] = [];
+    let settled = false;
+    const command = process.env.CODEX_CLI || 'codex';
+    const tempDir = mkdtempSync(join(tmpdir(), 'amerikagundemi-codex-'));
+    const outputFile = join(tempDir, 'last-message.txt');
+
+    const child = spawn(command, [
+      'exec',
+      '--ephemeral',
+      '--skip-git-repo-check',
+      '--sandbox',
+      'read-only',
+      '--cd',
+      '/tmp',
+      '--output-last-message',
+      outputFile,
+      '-',
+    ], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env },
+    });
+
+    function cleanup(): void {
+      try {
+        rmSync(tempDir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors; the generation result is more important.
+      }
+    }
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill('SIGTERM');
+        cleanup();
+        resolve({ stdout: '', stderr: 'ETIMEDOUT: Process timed out', exitCode: -1 });
+      }
+    }, timeoutMs);
+
+    child.stdout.on('data', (chunk: Buffer) => chunks.push(chunk));
+    child.stderr.on('data', (chunk: Buffer) => errChunks.push(chunk));
+
+    child.on('error', (err) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        cleanup();
+        resolve({ stdout: '', stderr: err.message, exitCode: -1 });
+      }
+    });
+
+    child.on('close', (code) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        const stdoutLog = Buffer.concat(chunks).toString('utf-8');
+        const stderr = Buffer.concat(errChunks).toString('utf-8');
+        const finalMessage = existsSync(outputFile) ? readFileSync(outputFile, 'utf-8') : '';
+        cleanup();
+        resolve({
+          stdout: finalMessage,
+          stderr: stderr || stdoutLog,
+          exitCode: code ?? -1,
+        });
+      }
+    });
+
+    child.stdin.write(prompt);
+    child.stdin.end();
+  });
+}
+
 // Order-independent section parser. Finds all markers, sorts by position,
-// and slices content between them. Works regardless of output order from Claude.
+// and slices content between them. Works regardless of output order.
 function parseSections(raw: string, markers: readonly string[]): Record<string, string> | null {
   const found: { marker: string; pos: number }[] = [];
 
@@ -125,6 +216,8 @@ function parseCommaSeparated(raw: string): string[] {
 }
 
 function parseSummaryOnlyOutput(raw: string): Omit<TranslationResult, 'fullTranslation'> | null {
+  if (raw.includes('---FULL_TRANSLATION---')) return null;
+
   const sections = parseSections(raw, SUMMARY_ONLY_MARKERS);
   if (!sections) return null;
 
@@ -204,16 +297,16 @@ export async function translate(
 ): Promise<TranslationOutcome> {
   const systemPrompt = readFileSync(resolvePromptPath(config.translation.promptFile), 'utf-8');
   const words = wordCount(transcript);
+  const generator = selectedGenerator();
 
-  logger.info({ videoId, words }, 'Starting translation');
+  logger.info({ videoId, words, generator }, 'Starting translation');
 
-  // Single-pass: transcript fits in one invocation
   // Single-pass works for shorter transcripts. For longer ones, the output
   // (summary + full translation) becomes too large and times out.
-  // Threshold: ~6000 words input → ~8000 words output is safe for single pass.
+  // Threshold: ~6000 words input -> ~8000 words output is safe for single pass.
   if (words <= 6000) {
     const fullPrompt = `${systemPrompt}\n\n---TRANSCRIPT---\n${transcript}`;
-    const { stdout, stderr, exitCode } = await invokeClaude(fullPrompt, config.translation.timeoutSingleMs);
+    const { stdout, stderr, exitCode } = await invokeArticleGenerator(fullPrompt, config.translation.timeoutSingleMs);
 
     if (exitCode === -1 && stderr.includes('ETIMEDOUT')) {
       return { ok: false, error: 'timeout', details: `Timed out after ${config.translation.timeoutSingleMs}ms (${words} words)` };
@@ -227,16 +320,16 @@ export async function translate(
       return { ok: false, error: 'malformed_output', details: `Missing section markers in output (${stdout.length} chars)` };
     }
 
-    logger.info({ videoId, strategy: 'single' }, 'Translation complete');
+    logger.info({ videoId, generator, strategy: 'single' }, 'Translation complete');
     return { ok: true, result };
   }
 
   // Two-pass: transcript too long
-  logger.info({ videoId, words }, 'Transcript too long for single pass, using two-pass strategy');
+  logger.info({ videoId, words, generator }, 'Transcript too long for single pass, using two-pass strategy');
 
   // Pass 1: Summary + metadata (no full translation)
-  const pass1Prompt = `${systemPrompt}\n\nIMPORTANT: For this invocation, produce only these sections: ---SUMMARY_ARTICLE---, ---TITLE---, ---GUESTS---, ---TAGS---, ---THREAD---. Do NOT produce ---FULL_TRANSLATION---.\n\n---TRANSCRIPT---\n${transcript}`;
-  const pass1 = await invokeClaude(pass1Prompt, config.translation.timeoutSingleMs);
+  const pass1Prompt = `${systemPrompt}\n\nIMPORTANT: For this invocation, produce only these sections: ---SUMMARY_ARTICLE---, ---TITLE---, ---GUESTS---, ---TAGS---, ---THREAD---. Do NOT produce ---FULL_TRANSLATION---. Return only the requested content, with no preamble, process notes, or commentary.\n\n---TRANSCRIPT---\n${transcript}`;
+  const pass1 = await invokeArticleGenerator(pass1Prompt, config.translation.timeoutSingleMs);
 
   if (pass1.exitCode === -1 && pass1.stderr.includes('ETIMEDOUT')) {
     return { ok: false, error: 'timeout', details: `Pass 1 timed out (${words} words)` };
@@ -259,15 +352,15 @@ export async function translate(
     let chunkPrompt: string;
 
     if (i === 0) {
-      chunkPrompt = `Translate the following podcast transcript excerpt to Turkish. Structure into readable paragraphs with ## section headers where the topic changes. Keep proper nouns in English. Use established Turkish equivalents for US political terms.\n\n---TRANSCRIPT CHUNK ${i + 1}/${chunks.length}---\n${chunk}`;
+      chunkPrompt = `Translate the following podcast transcript excerpt to Turkish. Return only the Turkish translation content, with no preamble, process notes, or commentary. Structure into readable paragraphs with ## section headers where the topic changes. Clearly label speakers when identifiable. Keep proper nouns in English. Use established Turkish equivalents for US political terms.\n\n---TRANSCRIPT CHUNK ${i + 1}/${chunks.length}---\n${chunk}`;
     } else {
       const overlap = getOverlapContext(translatedChunks[i - 1], 200);
-      chunkPrompt = `Continue translating this podcast transcript to Turkish. Maintain consistent terminology with the previous section. Previous translated section ended with:\n\n"${overlap}"\n\n---TRANSCRIPT CHUNK ${i + 1}/${chunks.length}---\n${chunk}`;
+      chunkPrompt = `Continue translating this podcast transcript to Turkish. Return only the Turkish translation content, with no preamble, process notes, or commentary. Maintain consistent terminology with the previous section. Previous translated section ended with:\n\n"${overlap}"\n\n---TRANSCRIPT CHUNK ${i + 1}/${chunks.length}---\n${chunk}`;
     }
 
-    logger.info({ videoId, chunk: i + 1, total: chunks.length }, 'Translating chunk');
+    logger.info({ videoId, chunk: i + 1, total: chunks.length, generator }, 'Translating chunk');
 
-    const chunkResult = await invokeClaude(chunkPrompt, config.translation.timeoutChunkMs);
+    const chunkResult = await invokeArticleGenerator(chunkPrompt, config.translation.timeoutChunkMs);
 
     if (chunkResult.exitCode === -1 && chunkResult.stderr.includes('ETIMEDOUT')) {
       return { ok: false, error: 'timeout', details: `Chunk ${i + 1}/${chunks.length} timed out` };
@@ -286,7 +379,7 @@ export async function translate(
 
   const fullTranslation = translatedChunks.join('\n\n');
 
-  logger.info({ videoId, strategy: 'two_pass', chunks: chunks.length }, 'Translation complete');
+  logger.info({ videoId, generator, strategy: 'two_pass', chunks: chunks.length }, 'Translation complete');
   return {
     ok: true,
     result: {

--- a/pipeline/src/youtube-transcript.d.ts
+++ b/pipeline/src/youtube-transcript.d.ts
@@ -1,0 +1,5 @@
+declare module 'youtube-transcript/dist/youtube-transcript.esm.js' {
+  export class YoutubeTranscript {
+    static fetchTranscript(videoId: string): Promise<unknown[]>;
+  }
+}


### PR DESCRIPTION
## Summary

- Runs article generation through Codex CLI by default, with `ARTICLE_GENERATOR=claude` kept as an explicit fallback.
- Preserves both `Özet Makale` and `Tam Çeviri`, including the long-transcript two-pass flow.
- Updates provider copy/env docs and repairs generated metadata/type issues that blocked required verification.

## Test plan

- `PATH=/Users/tugrultasgetiren/.nvm/versions/node/v22.22.1/bin:$PATH npx tsc --noEmit` in `pipeline/`
- `PATH=/Users/tugrultasgetiren/.nvm/versions/node/v22.22.1/bin:$PATH npm run build` in `blog/`
- `ARTICLE_GENERATOR=codex PATH=/Users/tugrultasgetiren/.nvm/versions/node/v22.22.1/bin:$PATH npx tsx /private/tmp/amerikagundemi-codex-smoke.mts`
- Real-transcript smoke verified title, summary article, full translation, tags, thread, and no marker leakage

Related issue: #27
