### PR TITLE
Add All-In podcast source

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,7 +2,9 @@
   "youtube": {
     "channels": [
       "https://www.youtube.com/channel/UCDkEYb-TXJVWLvOokshtlsw",
-      "https://www.youtube.com/@GDiesen1"
+      "https://www.youtube.com/@GDiesen1",
+      "https://www.youtube.com/thethinkingmuslim",
+      "https://www.youtube.com/@allin"
     ],
     "playlists": [],
     "manualUrls": [


### PR DESCRIPTION
## Summary
- Adds the normalized All-In Podcast YouTube handle to the monitored channel list.
- Preserves existing source entries, including the local The Thinking Muslim source.

## Test plan
- Parsed `config.json` with Node.
- Fetched `https://www.youtube.com/@allin` and verified canonical channel `UCESLZhusAkFfsNsApnjF_Cg` / title `All-In Podcast`.

Closes #29