### PR TITLE
Add Google tag analytics script

### DIFF
--- a/blog/src/layouts/BaseLayout.astro
+++ b/blog/src/layouts/BaseLayout.astro
@@ -55,6 +55,16 @@ const canonical = canonicalUrl || Astro.url.href;
     <meta name="twitter:description" content={description} />
     {ogImage && <meta name="twitter:image" content={ogImage} />}
 
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-RS1QBK6RDW"></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-RS1QBK6RDW');
+    </script>
+
     {isAdsenseEnabled && (
       <script
         async


### PR DESCRIPTION
## Summary
- Adds the Google tag (`G-RS1QBK6RDW`) to the shared Astro base layout.
- Loads the GA4 script on every page rendered through `BaseLayout`.

## Test plan
- `npm run build` from `blog/`
- Verified generated homepage HTML includes `G-RS1QBK6RDW`.
- Verified generated article/page HTML includes `G-RS1QBK6RDW`.

Closes #34
