### PR TITLE
Fix automatic content runner recovery

### DIFF
--- a/blog/src/pages/admin.astro
+++ b/blog/src/pages/admin.astro
@@ -205,12 +205,22 @@ export const prerender = true;
     twitter_published: { label: 'Yayında', cls: 'status-published' },
     no_transcript: { label: 'Transkript Yok', cls: 'status-error' },
     translation_timeout: { label: 'Zaman Aşımı', cls: 'status-error' },
+    translation_cli_error: { label: 'Çeviri CLI Hatası', cls: 'status-error' },
+    translation_malformed_output: { label: 'Hatalı Çeviri Çıktısı', cls: 'status-error' },
     translation_error: { label: 'Çeviri Hatası', cls: 'status-error' },
     translation_malformed: { label: 'Hatalı Çıktı', cls: 'status-error' },
     permanently_failed: { label: 'Başarısız', cls: 'status-error' },
   };
 
-  var ERROR_STATUSES = ['no_transcript', 'translation_timeout', 'translation_error', 'translation_malformed', 'permanently_failed'];
+  var ERROR_STATUSES = [
+    'no_transcript',
+    'translation_timeout',
+    'translation_cli_error',
+    'translation_malformed_output',
+    'translation_error',
+    'translation_malformed',
+    'permanently_failed',
+  ];
 
   function getStatusInfo(status) {
     return STATUS_LABELS[status] || { label: status, cls: 'status-pending' };

--- a/pipeline/src/db.ts
+++ b/pipeline/src/db.ts
@@ -73,7 +73,14 @@ export function getVideosByStatus(status: VideoStatus): VideoRecord[] {
 export function getRetryableVideos(): VideoRecord[] {
   return getDb().prepare(`
     SELECT * FROM videos
-    WHERE status IN ('translation_timeout', 'translation_error', 'translation_malformed', 'no_transcript')
+    WHERE status IN (
+      'translation_timeout',
+      'translation_cli_error',
+      'translation_malformed_output',
+      'translation_error',
+      'translation_malformed',
+      'no_transcript'
+    )
     AND retry_count < ?
   `).all(3) as VideoRecord[];
 }

--- a/pipeline/src/index.ts
+++ b/pipeline/src/index.ts
@@ -82,6 +82,15 @@ function translationFromVideo(video: VideoRecord): TranslationResult {
   };
 }
 
+const RETRYABLE_TRANSLATION_STATUSES = [
+  'translation_timeout',
+  'translation_cli_error',
+  'translation_malformed_output',
+  // Legacy names kept for existing local DB rows from older pipeline versions.
+  'translation_error',
+  'translation_malformed',
+] as const;
+
 async function processVideo(
   video: VideoRecord,
   config: Config,
@@ -91,7 +100,7 @@ async function processVideo(
   const { video_id: videoId, status, retry_count: retryCount } = video;
 
   // Check retry limit for error states
-  if (['translation_timeout', 'translation_error', 'translation_malformed'].includes(status)) {
+  if ((RETRYABLE_TRANSLATION_STATUSES as readonly string[]).includes(status)) {
     if (retryCount >= config.translation.maxRetries) {
       logger.warn({ videoId, retryCount }, 'Max retries reached, marking as permanently failed');
       markPermanentlyFailed(videoId);
@@ -112,7 +121,10 @@ async function processVideo(
   const afterTranscript = getVideoByVideoId(videoId)!;
 
   // Stage: Translation
-  if (afterTranscript.status === 'transcribed' || ['translation_timeout', 'translation_error', 'translation_malformed'].includes(afterTranscript.status)) {
+  if (
+    afterTranscript.status === 'transcribed'
+    || (RETRYABLE_TRANSLATION_STATUSES as readonly string[]).includes(afterTranscript.status)
+  ) {
     const transcript = afterTranscript.cleaned_transcript!;
     const outcome = await translate(transcript, videoId, config);
 
@@ -353,9 +365,8 @@ async function main(): Promise<void> {
     const formattedVideos = getVideosByStatus('formatted');
 
     // Collect retryable error videos
-    const retryableStatuses = ['translation_timeout', 'translation_error', 'translation_malformed'] as const;
     const retryableVideos: VideoRecord[] = [];
-    for (const status of retryableStatuses) {
+    for (const status of RETRYABLE_TRANSLATION_STATUSES) {
       retryableVideos.push(...getVideosByStatus(status).filter((v) => v.retry_count < config.translation.maxRetries));
     }
 

--- a/pipeline/src/queue.ts
+++ b/pipeline/src/queue.ts
@@ -3,13 +3,25 @@ import type { Config, VideoRecord } from './types.js';
 
 const QUEUE_API = '/api/queue';
 const VIDEOS_API = '/api/videos';
+const REMOTE_API_TIMEOUT_MS = 240000;
+
+async function fetchRemote(apiUrl: string, init: RequestInit = {}): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REMOTE_API_TIMEOUT_MS);
+
+  try {
+    return await fetch(apiUrl, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
 
 export async function fetchQueuedUrls(config: Config): Promise<string[]> {
   const baseUrl = (config.blog as any).workerUrl || config.blog.siteUrl;
   const apiUrl = `${baseUrl}${QUEUE_API}`;
 
   try {
-    const res = await fetch(apiUrl);
+    const res = await fetchRemote(apiUrl);
     if (!res.ok) {
       logger.warn({ status: res.status }, 'Failed to fetch queue from API');
       return [];
@@ -33,7 +45,7 @@ export async function markProcessed(config: Config, videoId: string): Promise<vo
   const apiUrl = `${baseUrl}${QUEUE_API}`;
 
   try {
-    await fetch(apiUrl, {
+    await fetchRemote(apiUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'remove', videoId }),
@@ -60,7 +72,7 @@ export async function syncVideosToRemote(config: Config, videos: VideoRecord[]):
   }));
 
   try {
-    const res = await fetch(apiUrl, {
+    const res = await fetchRemote(apiUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ videos: payload }),

--- a/pipeline/src/types.ts
+++ b/pipeline/src/types.ts
@@ -21,6 +21,8 @@ export type VideoStatus =
   | 'skipped_short'
   | 'no_transcript'
   | 'translation_timeout'
+  | 'translation_cli_error'
+  | 'translation_malformed_output'
   | 'translation_error'
   | 'translation_malformed'
   | 'permanently_failed';

--- a/run-pipeline.sh
+++ b/run-pipeline.sh
@@ -3,6 +3,17 @@ set -euo pipefail
 
 PROJECT_DIR="/Volumes/Crucial X10/Claude Code Projects/AmerikaGundemi"
 LOG_DIR="$HOME/.amerikagundemi/logs"
+NODE_BIN="$HOME/.nvm/versions/node/v25.2.1/bin"
+CODEX_RESOURCES="/Applications/Codex.app/Contents/Resources"
+CODEX_PLUGIN="$HOME/.codex/plugins/.plugin-appserver"
+
+export PATH="$CODEX_RESOURCES:$CODEX_PLUGIN:$NODE_BIN:$PATH"
+
+if [ -x "$CODEX_RESOURCES/codex" ]; then
+  export CODEX_CLI="$CODEX_RESOURCES/codex"
+elif [ -x "$CODEX_PLUGIN/codex" ]; then
+  export CODEX_CLI="$CODEX_PLUGIN/codex"
+fi
 
 mkdir -p "$LOG_DIR"
 


### PR DESCRIPTION
## Summary
- Expose Node 25 and Codex CLI paths in the cron runner so article generation can spawn Codex outside an interactive shell.
- Retry the real stored translation failure statuses: `translation_cli_error` and `translation_malformed_output`.
- Add admin labels for those statuses and timeout remote queue/video sync calls.

Closes #36

## Test plan
- `PATH=/Users/tugrultasgetiren/.nvm/versions/node/v25.2.1/bin:$PATH /Users/tugrultasgetiren/.nvm/versions/node/v25.2.1/bin/npx tsc --noEmit` from `pipeline/`
- `PATH=/Users/tugrultasgetiren/.nvm/versions/node/v22.22.1/bin:$PATH /Users/tugrultasgetiren/.nvm/versions/node/v22.22.1/bin/npm run build` from `blog/`
- Codex CLI smoke test with runner PATH/CODEX_CLI returned `OK`
- `PATH=/Users/tugrultasgetiren/.nvm/versions/node/v25.2.1/bin:$PATH /Users/tugrultasgetiren/.nvm/versions/node/v25.2.1/bin/npx tsx pipeline/src/index.ts --status`