### PR TITLE
Harden watchdog recovery

### DIFF
--- a/blog/src/components/PostMeta.astro
+++ b/blog/src/components/PostMeta.astro
@@ -1,4 +1,6 @@
 ---
+import { channelSlug, tagSlug } from '../lib/slugs';
+
 interface Props {
   channel: string;
   date: Date;
@@ -13,7 +15,7 @@ const formattedDate = date.toLocaleDateString('tr-TR', { year: 'numeric', month:
 
 <div class="post-meta">
   <div class="meta-row">
-    <a href={`/kanal/${channel.toLowerCase().replace(/\s+/g, '-')}`} class="channel">{channel}</a>
+    <a href={`/kanal/${channelSlug(channel)}`} class="channel">{channel}</a>
     <time datetime={date.toISOString()}>{formattedDate}</time>
     <span class="reading-time">Özet: {readingTime.summary} dk · Tam çeviri: {readingTime.full} dk</span>
   </div>
@@ -30,7 +32,7 @@ const formattedDate = date.toLocaleDateString('tr-TR', { year: 'numeric', month:
   )}
   <div class="meta-row tags-row">
     {tags.map((tag) => (
-      <a href={`/etiket/${tag.toLowerCase().replace(/\s+/g, '-')}`} class="tag">{tag}</a>
+      <a href={`/etiket/${tagSlug(tag)}`} class="tag">{tag}</a>
     ))}
   </div>
 </div>

--- a/blog/src/components/TagCloud.astro
+++ b/blog/src/components/TagCloud.astro
@@ -1,4 +1,6 @@
 ---
+import { tagSlug } from '../lib/slugs';
+
 interface Props {
   tags: Map<string, number>;
   max?: number;
@@ -13,7 +15,7 @@ const sorted = [...tags.entries()]
 {sorted.length > 0 && (
   <div class="tag-cloud">
     {sorted.map(([tag, count]) => (
-      <a href={`/etiket/${tag.toLowerCase().replace(/\s+/g, '-')}`} class="tag-item">
+      <a href={`/etiket/${tagSlug(tag)}`} class="tag-item">
         {tag} <span class="count">({count})</span>
       </a>
     ))}

--- a/blog/src/content/posts/naftali-bennett-i-ran-rejiminin-en-kotu-kabusu-olacagim.md
+++ b/blog/src/content/posts/naftali-bennett-i-ran-rejiminin-en-kotu-kabusu-olacagim.md
@@ -1,0 +1,82 @@
+---
+title: "Naftali Bennett: “İran Rejiminin En Kötü Kabusu Olacağım”"
+date: 2026-07-02
+source: "https://www.youtube.com/watch?v=OqifD_whzi4"
+channel: "Judge Napolitano - Judging Freedom"
+videoId: "OqifD_whzi4"
+description: "Kaynak dili İngilizce olan kayıtta, Naftali Bennett’in Piers Morgan programında İran rejimine yönelik sert mesajları ve buna verilen eleştirel yanıtlar tartışıldı. Bölümde İran’ın nükleer silah edinme ihtimali, Donald Trump’ın “koşulsuz teslim” çıkış"
+tags: ["İran","İsrail","ABD dış politikası","nükleer silahlar","Orta Doğu","Lübnan","Donald Trump","Naftali Bennett"]
+guests: ["Naftali Bennett","Piers Morgan","Donald Trump","Larry Johnson"]
+category: "siyaset"
+readingTime:
+  summary: 3
+  full: 1
+---
+
+Kaynak dili İngilizce olan kayıtta, Naftali Bennett’in Piers Morgan programında İran rejimine yönelik sert mesajları ve buna verilen eleştirel yanıtlar tartışıldı. Bölümde İran’ın nükleer silah edinme ihtimali, Donald Trump’ın “koşulsuz teslim” çıkışı, İsrail’in askeri kapasitesi ve Lübnan bağlantılı gerilimler öne çıktı.
+
+## Bennett’in İran’a Mesajı
+
+Programda önce Bennett’in İran’a dönük tehdidi aktarıldı. Sunucu, Bennett’in İran’a esasen “Umutlanmayın, çünkü kazanırsam en kötü kabusunuz olacağım” dediğini belirtti ve bunun Piers Morgan’la yaptığı görüşmeden alındığını söyledi.
+
+“İran rejimine buradan şunu söylemek istiyorum: Bugüne kadarki en kötü kabusunuz olacağım,” diyen Naftali Bennett, İran’a karşı geri adım atmayacağını savundu.
+
+## Trump’ın “Koşulsuz Teslim” Sözü
+
+Piers Morgan, konuşmada Donald Trump’ın Mart 2026’da İran hakkında yaptığı açıklamayı hatırlattı. “Başkan Trump Mart 2026’da, ‘İran’la koşulsuz teslim dışında hiçbir anlaşma olmayacak’ dedi,” diyen Piers Morgan, Bennett’e mevcut durumun bu noktadan uzak olup olmadığını sordu.
+
+Bennett ise İran’ı “büyük ve şiddet yanlısı bir zorba” olarak niteledi. “Az önce tarif ettiğiniz şey, İran’ın büyük ve şiddet yanlısı bir zorba olduğudur,” diyen Bennett, bunun İran’ın nükleer silah edinmesinin engellenmesi gerektiğini gösterdiğini belirtti.
+
+Bennett’e göre mesele yalnızca İsrail’in güvenliği değil, tüm bölgenin güvenliğiydi. “Dünyayı terörize edemeyeceğinden emin olmalıyız,” diyen Bennett, İran’ın nükleer silah edinmesi halinde tablonun çok daha tehlikeli olacağını ifade etti.
+
+## Nükleer Silah Tartışması
+
+Bennett’in ana argümanı, İran’ın nükleer kapasiteye ulaşmasının engellenmesi gerektiği üzerine kuruldu. “Şimdi nükleer silah edinirse bunun nasıl görüneceğini hayal edin,” diyen Bennett, İran’ın davranışlarının dünyaya “gerçek İran’ı” gösterdiğini savundu.
+
+Bennett konuşmasının devamında İran halkına da atıf yaptı. “Halkınızı özgürleştirene, nükleer silahınız olmadığından emin olana kadar geri adım atmayacağım,” diyen Bennett, bu mücadelenin “özgürlük”, “güvenlik” ve “tüm Orta Doğu’nun yararı” için sürdürüldüğünü vurguladı.
+
+## Askeri Gerçeklik Eleştirisi
+
+Kayıtta daha sonra Bennett’in yaklaşımına sert bir eleştiri geldi. Sunucu, Bennett’in askeri denklemi doğru okumadığını söyledi. “Sanırım askeri gerçekleri gerçekten anlamıyor,” diyen Sunucu, Larry Johnson’a atıfla İsrail’in ABD desteği olmadan İran’a karşı dayanamayacağını aktardı.
+
+Sunucu bu iddiayı sayı vererek dile getirdi: ABD İran’a karşı İsrail’le birlikte savaşmazsa, Larry Johnson’a göre İsrail “altı ya da yedi gün içinde” yenilgiye uğrayabilirdi. Bu ifade, Bennett’in sert söylemi ile sahadaki askeri kapasite arasında fark olduğu iddiasını ortaya koydu.
+
+## “Savaş Kışkırtıcısı” Eleştirisi
+
+Bir başka konuşmacı ise Bennett’i çok daha sert sözlerle hedef aldı. “Bu, savaş kışkırtıcısı bir başka Siyonist,” diyen Konuk, İran’ın Bennett’in tehdidinden korkacağı fikrini alaycı bir dille reddetti.
+
+Konuk, İranlıların “korkudan titrediği” yönündeki imayı ironik biçimde ele aldı. “Vay canına. Yeni en kötü kabus. Aman, kaçmamız lazım. Hayır, bu olmayacak,” diyen Konuk, Bennett’in tehdidinin Tahran üzerinde beklenen etkiyi yaratmayacağını savundu.
+
+## Lübnan ve İki Taraflı Taahhütler
+
+Tartışmanın son bölümünde konu Lübnan’a kaydı. Konuk, bundan sonra İsrail’in Lübnan’a yönelik saldırılarının daha geniş bir taahhütler zinciri içinde değerlendirileceğini söyledi. “En önemli mesele Lübnan,” diyen Konuk, İsrail’in Lübnan’a saldırılarının Tahran’da doğrudan ABD ile bağlantılı okunacağını belirtti.
+
+Konuk, İsrail’in bir mutabakatı veya taahhüdü bozması halinde bunun ABD tarafından da bozulmuş sayılacağını ifade etti. “İsrail onu bozarsa, ABD de onu bozmuş olur,” diyen Konuk, Tahran’daki yorumun bu yönde olacağını açıkladı.
+
+Bu çerçevede Konuk, İran tarafının Amerikalılara yeni bir mesaj verdiğini savundu. “Bundan böyle taahhütler iki taraflıdır,” diyen Konuk, ABD veya İsrail’in adım atması halinde karşı tarafın da aynı şekilde ve daha sert karşılık verebileceğini ifade etti.
+
+Konuk, “Siz bozarsanız, biz de bozarız; hem de sizin yaptığınızdan 1,5 kat, iki kat daha sert biçimde bozabiliriz,” diyerek gerilimin artık tek taraflı dayatmalarla yönetilemeyeceğini savundu. Ona göre Amerikalılar, “paradigmanın tamamen değiştiğini” hâlâ anlamıyordu.
+
+<!-- FULL_TRANSLATION -->
+
+## Bennett’in Piers Morgan’daki Sözleri
+
+**Sunucu:** Esasen İran’a, “Umutlanmayın, çünkü kazanırsam en kötü kabusunuz olacağım” diyor. Bu, Piers Morgan’la yaptığı konuşmadan.
+
+**Naftali Bennett:** İran rejimine buradan şunu söylemek istiyorum: “Bugüne kadarki en kötü kabusunuz olacağım.”
+
+**Piers Morgan:** Başkan Trump Mart 2026’da, “İran’la koşulsuz teslim dışında hiçbir anlaşma olmayacak” dedi. Bundan oldukça uzağız, değil mi, Naftali Bennett?
+
+**Naftali Bennett:** Az önce tarif ettiğiniz şey, İran’ın büyük ve şiddet yanlısı bir zorba olduğudur ve bu, onun nükleer silah edinmemesini sağlamamız gerektiğini daha da kanıtlıyor. Dünyayı terörize edemeyeceğinden emin olmalıyız. Şimdi nükleer silah edinirse bunun nasıl görüneceğini hayal edin.
+
+**Naftali Bennett:** Dolayısıyla her hâlükârda hepimiz gerçek İran’ı gördük. İran rejimine buradan şunu söylemek istiyorum: En kötü kabusunuz olacağım. Halkınızı özgürleştirene, nükleer silahınız olmadığından emin olana kadar geri adım atmayacağım. Bu çabayı gevşetmeyeceğiz; çünkü bu, özgürlüğümüz, güvenliğimiz ve tüm Orta Doğu’nun yararı için verilen bir mücadeledir.
+
+## Askeri Gerçeklik ve Lübnan
+
+**Sunucu:** Sanırım askeri gerçekleri gerçekten anlamıyor. Larry Johnson’a göre ABD İran’a karşı İsrail’le birlikte savaşmazsa, altı ya da yedi gün içinde yok olurlar.
+
+**Konuk:** Eh, bu savaş kışkırtıcısı bir başka Siyonist. İranlılar da şimdiden korkudan titriyor. Vay canına. Yeni en kötü kabus. “Aman, kaçmamız lazım.” Hayır, bu olmayacak.
+
+**Konuk:** Ve tabii en önemli şey Lübnan. Bundan sonra İsrail’in Lübnan’a saldırıları açısından ne olursa olsun, her şey doğrudan o taahhüde bağlanacak. Bu, İsrail onu bozarsa ABD’nin de onu bozduğu anlamına gelir. Tahran’da bu şekilde yorumlanacak.
+
+**Konuk:** Ve Amerikalılara temelde şunu söylüyorlar: Bundan böyle taahhütler iki taraflıdır. Yani siz bozarsanız, biz de bozarız; hem de sizin yaptığınızdan 1,5 kat, iki kat daha sert biçimde bozabiliriz. Amerikalılar hâlâ paradigmanın tamamen değiştiğini anlamıyor.

--- a/blog/src/layouts/PostLayout.astro
+++ b/blog/src/layouts/PostLayout.astro
@@ -8,6 +8,7 @@ import Breadcrumbs from '../components/Breadcrumbs.astro';
 import SourceAttribution from '../components/SourceAttribution.astro';
 import RelatedPosts from '../components/RelatedPosts.astro';
 import TableOfContents from '../components/TableOfContents.astro';
+import { channelSlug } from '../lib/slugs';
 
 interface Props {
   post: CollectionEntry<'posts'>;
@@ -69,12 +70,12 @@ const jsonLd = {
 
   <main class="post-page">
     <Breadcrumbs crumbs={[
-      { label: channel, href: `/kanal/${channel.toLowerCase().replace(/\s+/g, '-')}` },
+      { label: channel, href: `/kanal/${channelSlug(channel)}` },
       { label: title },
     ]} />
 
     <article>
-      <a href={`/kanal/${channel.toLowerCase().replace(/\s+/g, '-')}`} class="hero-channel">{channel}</a>
+      <a href={`/kanal/${channelSlug(channel)}`} class="hero-channel">{channel}</a>
       <h1>{title}</h1>
 
       <PostMeta

--- a/blog/src/lib/slugs.ts
+++ b/blog/src/lib/slugs.ts
@@ -1,0 +1,16 @@
+function routeSlug(value: string, fallback: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[\\/]+/g, '-')
+    .replace(/^-+|-+$/g, '') || fallback;
+}
+
+export function tagSlug(tag: string): string {
+  return routeSlug(tag, 'etiket');
+}
+
+export function channelSlug(channel: string): string {
+  return routeSlug(channel, 'kanal');
+}

--- a/blog/src/pages/etiket/[tag].astro
+++ b/blog/src/pages/etiket/[tag].astro
@@ -4,18 +4,30 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
 import PostCard from '../../components/PostCard.astro';
+import { tagSlug } from '../../lib/slugs';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts');
-  const tags = new Set<string>();
-  posts.forEach((p) => p.data.tags.forEach((t: string) => tags.add(t)));
+  const tagPages = new Map<string, { tag: string; posts: typeof posts }>();
 
-  return [...tags].map((tag) => ({
-    params: { tag: tag.toLowerCase().replace(/\s+/g, '-') },
+  for (const post of posts) {
+    for (const tag of post.data.tags) {
+      const slug = tagSlug(tag);
+      const page = tagPages.get(slug) ?? { tag, posts: [] };
+
+      if (!page.posts.some((p) => p.id === post.id)) {
+        page.posts.push(post);
+      }
+
+      tagPages.set(slug, page);
+    }
+  }
+
+  return [...tagPages.entries()].map(([slug, page]) => ({
+    params: { tag: slug },
     props: {
-      tag,
-      posts: posts
-        .filter((p) => p.data.tags.includes(tag))
+      tag: page.tag,
+      posts: page.posts
         .sort((a, b) => b.data.date.getTime() - a.data.date.getTime()),
     },
   }));

--- a/blog/src/pages/index.astro
+++ b/blog/src/pages/index.astro
@@ -5,6 +5,7 @@ import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import PostCard from '../components/PostCard.astro';
 import SearchBar from '../components/SearchBar.astro';
+import { channelSlug } from '../lib/slugs';
 
 const posts = (await getCollection('posts'))
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
@@ -63,7 +64,7 @@ const otherPosts = posts.slice(1);
             <div class="container">
               <div class="channels-scroll">
                 {channels.map((ch) => (
-                  <a href={`/kanal/${ch.toLowerCase().replace(/\s+/g, '-')}`} class="channel-chip">{ch}</a>
+                  <a href={`/kanal/${channelSlug(ch)}`} class="channel-chip">{ch}</a>
                 ))}
               </div>
             </div>

--- a/blog/src/pages/kanal/[channel].astro
+++ b/blog/src/pages/kanal/[channel].astro
@@ -4,18 +4,28 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
 import PostCard from '../../components/PostCard.astro';
+import { channelSlug } from '../../lib/slugs';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts');
-  const channels = new Set<string>();
-  posts.forEach((p) => channels.add(p.data.channel));
+  const channelPages = new Map<string, { channel: string; posts: typeof posts }>();
 
-  return [...channels].map((channel) => ({
-    params: { channel: channel.toLowerCase().replace(/\s+/g, '-') },
+  for (const post of posts) {
+    const slug = channelSlug(post.data.channel);
+    const page = channelPages.get(slug) ?? { channel: post.data.channel, posts: [] };
+
+    if (!page.posts.some((p) => p.id === post.id)) {
+      page.posts.push(post);
+    }
+
+    channelPages.set(slug, page);
+  }
+
+  return [...channelPages.entries()].map(([slug, page]) => ({
+    params: { channel: slug },
     props: {
-      channel,
-      posts: posts
-        .filter((p) => p.data.channel === channel)
+      channel: page.channel,
+      posts: page.posts
         .sort((a, b) => b.data.date.getTime() - a.data.date.getTime()),
     },
   }));

--- a/pipeline/src/publisher-blog.ts
+++ b/pipeline/src/publisher-blog.ts
@@ -29,6 +29,12 @@ export async function publishBlogPosts(
   const git = simpleGit(PROJECT_ROOT);
 
   try {
+    const branch = (await git.branch()).current;
+    if (branch !== 'main') {
+      logger.error({ branch }, 'Refusing to publish blog posts from a non-main branch');
+      return false;
+    }
+
     // Stage all new/modified post files
     const postsGlob = 'blog/src/content/posts/*.md';
     await git.add(postsGlob);
@@ -36,9 +42,16 @@ export async function publishBlogPosts(
     // Check if there are staged changes
     const status = await git.status();
     if (status.staged.length === 0) {
-      await git.push('origin', 'main');
+      await git.fetch('origin', 'main');
+      const aheadRaw = await git.raw(['rev-list', '--count', 'origin/main..HEAD']);
+      const aheadCount = Number.parseInt(aheadRaw.trim(), 10) || 0;
+
+      if (aheadCount > 0) {
+        await git.push('origin', 'main');
+      }
+
       markVideosPublished(videoIds);
-      logger.info({ count: videoIds.length }, 'No staged changes; pushed current branch state and marked posts published');
+      logger.info({ count: videoIds.length, aheadCount }, 'No staged changes; marked posts published');
       return true;
     }
 

--- a/run-pipeline.sh
+++ b/run-pipeline.sh
@@ -28,7 +28,16 @@ fi
 
 cd "$PROJECT_DIR"
 
+branch="$(git branch --show-current)"
+if [ "$branch" != "main" ]; then
+  echo "$(date): Current branch is $branch, expected main; skipping scheduled pipeline run" >> "$LOG_DIR/pipeline-$(date +%Y-%m-%d).log"
+  exit 1
+fi
+
 if [ -x "$GH_CLI" ]; then
+  git config --local --unset-all credential.helper || true
+  git config --local --add credential.helper ""
+  git config --local --add credential.helper "!$GH_CLI auth git-credential"
   git config --local --unset-all credential.https://github.com.helper || true
   git config --local --add credential.https://github.com.helper ""
   git config --local --add credential.https://github.com.helper "!$GH_CLI auth git-credential"

--- a/scripts/amerikagundemi-watchdog.sh
+++ b/scripts/amerikagundemi-watchdog.sh
@@ -15,28 +15,35 @@ GH_CLI="$HOMEBREW_BIN/gh"
 export PATH="$CODEX_RESOURCES:$CODEX_PLUGIN:$NODE_BIN:$HOMEBREW_BIN:$PATH"
 export GIT_TERMINAL_PROMPT=0
 
+timestamp() {
+  date "+%Y-%m-%dT%H:%M:%S%z"
+}
+
 mkdir -p "$LOG_DIR"
 exec >> "$LOG_DIR/watchdog-$(date +%Y-%m-%d).log" 2>&1
 
-echo "[$(date -Is)] watchdog starting"
+echo "[$(timestamp)] watchdog starting"
 
 if [ -f "$UNTIL_FILE" ]; then
   now_epoch="$(date +%s)"
   until_epoch="$(cat "$UNTIL_FILE")"
   if [ "$now_epoch" -gt "$until_epoch" ]; then
-    echo "[$(date -Is)] watchdog window expired"
+    echo "[$(timestamp)] watchdog window expired"
     exit 0
   fi
 fi
 
 if [ ! -d "$PROJECT_DIR" ]; then
-  echo "[$(date -Is)] project directory missing: $PROJECT_DIR"
+  echo "[$(timestamp)] project directory missing: $PROJECT_DIR"
   exit 1
 fi
 
 cd "$PROJECT_DIR"
 
 if [ -x "$GH_CLI" ]; then
+  git config --local --unset-all credential.helper || true
+  git config --local --add credential.helper ""
+  git config --local --add credential.helper "!$GH_CLI auth git-credential"
   git config --local --unset-all credential.https://github.com.helper || true
   git config --local --add credential.https://github.com.helper ""
   git config --local --add credential.https://github.com.helper "!$GH_CLI auth git-credential"
@@ -44,7 +51,7 @@ fi
 
 branch="$(git branch --show-current)"
 if [ "$branch" != "main" ]; then
-  echo "[$(date -Is)] current branch is $branch, expected main"
+  echo "[$(timestamp)] current branch is $branch, expected main"
   exit 1
 fi
 
@@ -54,7 +61,7 @@ git merge --ff-only origin/main || true
 formatted_count="$(sqlite3 "$DB_PATH" "select count(*) from videos where status='formatted';")"
 ahead_count="$(git rev-list --count origin/main..HEAD)"
 
-echo "[$(date -Is)] formatted=$formatted_count ahead=$ahead_count"
+echo "[$(timestamp)] formatted=$formatted_count ahead=$ahead_count"
 
 if [ "$formatted_count" -gt 0 ]; then
   npx tsx pipeline/src/index.ts --publish-formatted-only --skip-twitter
@@ -63,7 +70,7 @@ fi
 git fetch origin main
 ahead_count="$(git rev-list --count origin/main..HEAD)"
 if [ "$ahead_count" -gt 0 ]; then
-  echo "[$(date -Is)] pushing $ahead_count local commit(s)"
+  echo "[$(timestamp)] pushing $ahead_count local commit(s)"
   git push origin main
 fi
 
@@ -76,7 +83,7 @@ git fetch origin main
 formatted_count="$(sqlite3 "$DB_PATH" "select count(*) from videos where status='formatted';")"
 ahead_count="$(git rev-list --count origin/main..HEAD)"
 
-echo "[$(date -Is)] watchdog complete formatted=$formatted_count ahead=$ahead_count"
+echo "[$(timestamp)] watchdog complete formatted=$formatted_count ahead=$ahead_count"
 
 if [ "$formatted_count" -gt 0 ] || [ "$ahead_count" -gt 0 ]; then
   exit 1


### PR DESCRIPTION
## Summary
- skip redundant main pushes when formatted posts are already merged, and refuse publishing from non-main checkouts
- harden scheduled runner/watchdog Git credential setup and make the runner skip on feature branches
- fix slash-containing tag/channel route slugs and preserve the generated Naftali Bennett article from the interrupted 11:05 run

Closes #42

## Test plan
- `git diff --check`
- `PATH=/Users/tugrultasgetiren/.nvm/versions/node/v25.2.1/bin:$PATH /Users/tugrultasgetiren/.nvm/versions/node/v25.2.1/bin/npx tsc --noEmit` from `pipeline/`
- `bash -n run-pipeline.sh scripts/amerikagundemi-watchdog.sh`
- `PATH=/Users/tugrultasgetiren/.nvm/versions/node/v22.22.1/bin:$PATH /Users/tugrultasgetiren/.nvm/versions/node/v22.22.1/bin/npm run build > /tmp/amerikagundemi-build.log 2>&1` from `blog/`
- `rg -n "\[ERROR\]|Missing parameter|Could not render" /tmp/amerikagundemi-build.log` returned no matches
