### PR TITLE
Collapse repeated route slug hyphens

### DIFF
--- a/blog/src/lib/slugs.ts
+++ b/blog/src/lib/slugs.ts
@@ -4,6 +4,7 @@ function routeSlug(value: string, fallback: string): string {
     .toLowerCase()
     .replace(/\s+/g, '-')
     .replace(/[\\/]+/g, '-')
+    .replace(/-+/g, '-')
     .replace(/^-+|-+$/g, '') || fallback;
 }
 


### PR DESCRIPTION
## Summary
- collapse repeated hyphens in the shared route slug helper
- keeps slash-containing channel URLs clean, e.g. `/kanal/daniel-davis-deep-dive/`

Closes #44

## Test plan
- `git diff --check`
- `PATH=/Users/tugrultasgetiren/.nvm/versions/node/v22.22.1/bin:$PATH /Users/tugrultasgetiren/.nvm/versions/node/v22.22.1/bin/npm run build > /tmp/amerikagundemi-build-slugs.log 2>&1` from `blog/`
- `rg -n "\[ERROR\]|Missing parameter|Could not render" /tmp/amerikagundemi-build-slugs.log` returned no matches
- `rg -n "daniel-davis" /tmp/amerikagundemi-build-slugs.log` shows `/kanal/daniel-davis-deep-dive/index.html`
