### PR TITLE
Install GA4 tag

### DIFF
--- a/blog/src/layouts/BaseLayout.astro
+++ b/blog/src/layouts/BaseLayout.astro
@@ -55,6 +55,16 @@ const canonical = canonicalUrl || Astro.url.href;
     <meta name="twitter:description" content={description} />
     {ogImage && <meta name="twitter:image" content={ogImage} />}
 
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-RS1QBK6RDW"></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-RS1QBK6RDW');
+    </script>
+
     {isAdsenseEnabled && (
       <script
         async


### PR DESCRIPTION
## Summary

- add the provided Google tag / GA4 snippet to the shared Astro layout
- load measurement ID `G-RS1QBK6RDW` site-wide from the page `<head>`

Closes #48

## Test plan

- `npm run build` from `blog`
- confirmed built homepage contains `googletagmanager.com/gtag/js?id=G-RS1QBK6RDW`
- confirmed built homepage contains `gtag('config', 'G-RS1QBK6RDW')`
