### PR TITLE
Add newsletter subscriptions and summary-only pipeline

### DIFF
--- a/blog/src/components/Footer.astro
+++ b/blog/src/components/Footer.astro
@@ -1,4 +1,6 @@
 ---
+import NewsletterSignup from './NewsletterSignup.astro';
+
 const year = new Date().getFullYear();
 ---
 
@@ -18,6 +20,7 @@ const year = new Date().getFullYear();
         <a href="/rss.xml">RSS</a>
         <a href="https://buymeacoffee.com/gundemamerika" target="_blank" rel="noopener noreferrer" class="donate-link">Destek Ol</a>
       </div>
+      <NewsletterSignup />
     </div>
     <div class="footer-bottom">
       <p>&copy; {year} Gündem Amerika. Orijinal içerikler ilgili YouTube kanallarına aittir.</p>
@@ -45,7 +48,7 @@ const year = new Date().getFullYear();
     align-items: flex-start;
     padding-bottom: 1.5rem;
     border-bottom: 1px solid #1f2937;
-    gap: 2rem;
+    gap: 1.5rem;
   }
 
   .footer-logo {

--- a/blog/src/components/NewsletterSignup.astro
+++ b/blog/src/components/NewsletterSignup.astro
@@ -1,0 +1,133 @@
+<form class="newsletter-form" data-newsletter-form>
+  <label for="newsletter-email">Bültene abone olun</label>
+  <div class="newsletter-row">
+    <input
+      id="newsletter-email"
+      name="email"
+      type="email"
+      autocomplete="email"
+      inputmode="email"
+      placeholder="e-posta adresiniz"
+      required
+    />
+    <button type="submit">Abone ol</button>
+  </div>
+  <p class="newsletter-note">Yeni yazılar için onay bağlantısı gönderilir.</p>
+  <p class="newsletter-message" data-newsletter-message aria-live="polite"></p>
+</form>
+
+<script is:inline>
+  document.querySelectorAll('[data-newsletter-form]').forEach(function(form) {
+    form.addEventListener('submit', async function(event) {
+      event.preventDefault();
+      var email = form.querySelector('input[name="email"]');
+      var button = form.querySelector('button[type="submit"]');
+      var message = form.querySelector('[data-newsletter-message]');
+
+      if (!email || !button || !message) return;
+
+      button.disabled = true;
+      message.textContent = 'Gönderiliyor...';
+
+      try {
+        var response = await fetch('/api/subscribe', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: email.value }),
+        });
+        var data = await response.json();
+
+        if (!response.ok) {
+          message.textContent = data.error || 'Abonelik başlatılamadı.';
+          return;
+        }
+
+        message.textContent = data.message || 'Onay e-postası gönderildi.';
+        email.value = '';
+      } catch (_error) {
+        message.textContent = 'Abonelik başlatılamadı.';
+      } finally {
+        button.disabled = false;
+      }
+    });
+  });
+</script>
+
+<style>
+  .newsletter-form {
+    min-width: min(100%, 340px);
+  }
+
+  label {
+    display: block;
+    color: #f9fafb;
+    font-size: 0.82rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+  }
+
+  .newsletter-row {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  input {
+    min-width: 0;
+    flex: 1;
+    border: 1px solid #374151;
+    border-radius: 4px;
+    background: #111827;
+    color: #f9fafb;
+    font: inherit;
+    font-size: 0.85rem;
+    padding: 0.55rem 0.65rem;
+  }
+
+  input::placeholder {
+    color: #6b7280;
+  }
+
+  button {
+    border: 0;
+    border-radius: 4px;
+    background: var(--color-accent);
+    color: white;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.82rem;
+    font-weight: 700;
+    padding: 0.55rem 0.8rem;
+    white-space: nowrap;
+  }
+
+  button:disabled {
+    cursor: wait;
+    opacity: 0.65;
+  }
+
+  .newsletter-note,
+  .newsletter-message {
+    font-size: 0.72rem;
+    line-height: 1.45;
+    margin-top: 0.45rem;
+  }
+
+  .newsletter-note {
+    color: #9ca3af;
+  }
+
+  .newsletter-message {
+    color: #f9fafb;
+    min-height: 1rem;
+  }
+
+  @media (max-width: 420px) {
+    .newsletter-row {
+      flex-direction: column;
+    }
+
+    button {
+      width: 100%;
+    }
+  }
+</style>

--- a/blog/src/components/PostMeta.astro
+++ b/blog/src/components/PostMeta.astro
@@ -11,13 +11,17 @@ interface Props {
 
 const { channel, date, guests, tags, readingTime } = Astro.props;
 const formattedDate = date.toLocaleDateString('tr-TR', { year: 'numeric', month: 'long', day: 'numeric' });
+const hasFullTranslation = readingTime.full > 0;
 ---
 
 <div class="post-meta">
   <div class="meta-row">
     <a href={`/kanal/${channelSlug(channel)}`} class="channel">{channel}</a>
     <time datetime={date.toISOString()}>{formattedDate}</time>
-    <span class="reading-time">Özet: {readingTime.summary} dk · Tam çeviri: {readingTime.full} dk</span>
+    <span class="reading-time">
+      Özet makale: {readingTime.summary} dk
+      {hasFullTranslation && <> · Tam çeviri: {readingTime.full} dk</>}
+    </span>
   </div>
   {guests.length > 0 && (
     <div class="meta-row guests">

--- a/blog/src/lib/newsletter.ts
+++ b/blog/src/lib/newsletter.ts
@@ -1,0 +1,205 @@
+export type SubscriberStatus = 'pending' | 'active' | 'unsubscribed';
+
+export interface SubscriberRecord {
+  email: string;
+  emailHash: string;
+  status: SubscriberStatus;
+  createdAt: string;
+  updatedAt: string;
+  confirmedAt?: string;
+  unsubscribedAt?: string;
+  confirmationSentAt?: string;
+  unsubscribeToken: string;
+}
+
+export interface NewsletterPost {
+  title: string;
+  url: string;
+  description?: string;
+}
+
+export interface EmailBinding {
+  send(message: {
+    to: string | { email: string; name?: string };
+    from: string | { email: string; name?: string };
+    subject: string;
+    html?: string;
+    text?: string;
+    replyTo?: string | { email: string; name?: string };
+    headers?: Record<string, string>;
+  }): Promise<{ messageId: string }>;
+}
+
+export const SUBSCRIBER_PREFIX = 'newsletter:subscriber:';
+const CONFIRM_PREFIX = 'newsletter:confirm:';
+const UNSUBSCRIBE_PREFIX = 'newsletter:unsubscribe:';
+const RATE_PREFIX = 'newsletter:rate:';
+
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) && email.length <= 254;
+}
+
+export async function sha256(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export function randomToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return [...bytes].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export function subscriberKey(emailHash: string): string {
+  return `${SUBSCRIBER_PREFIX}${emailHash}`;
+}
+
+export function confirmationKey(token: string): string {
+  return `${CONFIRM_PREFIX}${token}`;
+}
+
+export function unsubscribeKey(token: string): string {
+  return `${UNSUBSCRIBE_PREFIX}${token}`;
+}
+
+export function rateKey(emailHash: string): string {
+  return `${RATE_PREFIX}${emailHash}`;
+}
+
+export function getBaseUrl(request: Request): string {
+  const configured = (import.meta.env.PUBLIC_SITE_URL as string | undefined)?.replace(/\/$/, '');
+  if (configured) return configured;
+  const url = new URL(request.url);
+  return `${url.protocol}//${url.host}`;
+}
+
+export function getSender(runtimeEnv: Record<string, unknown>): { email: string; name: string } {
+  const email = typeof runtimeEnv.NEWSLETTER_FROM === 'string'
+    ? runtimeEnv.NEWSLETTER_FROM
+    : 'bulten@gundemamerika.com';
+  return { email, name: 'Gündem Amerika' };
+}
+
+export function getReplyTo(runtimeEnv: Record<string, unknown>): { email: string; name: string } {
+  const email = typeof runtimeEnv.NEWSLETTER_REPLY_TO === 'string'
+    ? runtimeEnv.NEWSLETTER_REPLY_TO
+    : 'info@gundemamerika.com';
+  return { email, name: 'Gündem Amerika' };
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+export async function parseEmailRequest(request: Request): Promise<string | null> {
+  const contentType = request.headers.get('content-type') ?? '';
+
+  if (contentType.includes('application/json')) {
+    const body = await request.json() as { email?: unknown };
+    return typeof body.email === 'string' ? body.email : null;
+  }
+
+  const formData = await request.formData();
+  const email = formData.get('email');
+  return typeof email === 'string' ? email : null;
+}
+
+export function json(data: unknown, init?: ResponseInit): Response {
+  return Response.json(data, {
+    ...init,
+    headers: {
+      'Cache-Control': 'no-store',
+      ...(init?.headers ?? {}),
+    },
+  });
+}
+
+export function htmlPage(title: string, message: string, status = 200): Response {
+  const body = `<!doctype html>
+<html lang="tr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(title)} | Gündem Amerika</title>
+  <style>
+    body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; max-width: 640px; margin: 12vh auto; padding: 0 24px; line-height: 1.6; color: #111827; }
+    a { color: #b91c1c; }
+  </style>
+</head>
+<body>
+  <h1>${escapeHtml(title)}</h1>
+  <p>${escapeHtml(message)}</p>
+  <p><a href="/">Gündem Amerika ana sayfasına dön</a></p>
+</body>
+</html>`;
+
+  return new Response(body, {
+    status,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+export async function sendConfirmationEmail(
+  emailBinding: EmailBinding,
+  runtimeEnv: Record<string, unknown>,
+  subscriber: SubscriberRecord,
+  confirmUrl: string,
+): Promise<void> {
+  const from = getSender(runtimeEnv);
+  const replyTo = getReplyTo(runtimeEnv);
+  const html = `<p>Gündem Amerika bültenine aboneliğinizi onaylamak için aşağıdaki bağlantıya tıklayın:</p>
+<p><a href="${escapeHtml(confirmUrl)}">${escapeHtml(confirmUrl)}</a></p>
+<p>Bu isteği siz başlatmadıysanız bu e-postayı yok sayabilirsiniz.</p>`;
+  const text = `Gündem Amerika bültenine aboneliğinizi onaylamak için bağlantıyı açın:\n\n${confirmUrl}\n\nBu isteği siz başlatmadıysanız bu e-postayı yok sayabilirsiniz.`;
+
+  await emailBinding.send({
+    to: { email: subscriber.email },
+    from,
+    replyTo,
+    subject: 'Gündem Amerika bülten aboneliğinizi onaylayın',
+    html,
+    text,
+  });
+}
+
+export async function sendDigestEmail(
+  emailBinding: EmailBinding,
+  runtimeEnv: Record<string, unknown>,
+  subscriber: SubscriberRecord,
+  posts: NewsletterPost[],
+  unsubscribeUrl: string,
+  subject = 'Gündem Amerika: Yeni yazılar',
+): Promise<void> {
+  const from = getSender(runtimeEnv);
+  const replyTo = getReplyTo(runtimeEnv);
+  const itemsHtml = posts.map((post) => `<li>
+  <a href="${escapeHtml(post.url)}">${escapeHtml(post.title)}</a>
+  ${post.description ? `<br><span>${escapeHtml(post.description)}</span>` : ''}
+</li>`).join('');
+  const itemsText = posts.map((post) => `- ${post.title}\n  ${post.url}${post.description ? `\n  ${post.description}` : ''}`).join('\n\n');
+
+  await emailBinding.send({
+    to: { email: subscriber.email },
+    from,
+    replyTo,
+    subject,
+    html: `<p>Gündem Amerika'da yeni yazılar yayımlandı:</p><ul>${itemsHtml}</ul><p><a href="${escapeHtml(unsubscribeUrl)}">Abonelikten çık</a></p>`,
+    text: `Gündem Amerika'da yeni yazılar yayımlandı:\n\n${itemsText}\n\nAbonelikten çık: ${unsubscribeUrl}`,
+    headers: {
+      'List-Unsubscribe': `<${unsubscribeUrl}>`,
+    },
+  });
+}

--- a/blog/src/pages/api/confirm.ts
+++ b/blog/src/pages/api/confirm.ts
@@ -1,0 +1,52 @@
+import type { APIContext } from 'astro';
+import { env } from 'cloudflare:workers';
+import {
+  confirmationKey,
+  htmlPage,
+  subscriberKey,
+  type SubscriberRecord,
+} from '../../lib/newsletter';
+
+export const prerender = false;
+
+function getKV(): KVNamespace | undefined {
+  return (env as any).VIDEO_QUEUE;
+}
+
+export async function GET(context: APIContext): Promise<Response> {
+  const kv = getKV();
+  if (!kv) {
+    return htmlPage('Bülten yapılandırılmamış', 'Bülten servisi şu anda kullanılamıyor.', 503);
+  }
+
+  const token = new URL(context.request.url).searchParams.get('token')?.trim();
+  if (!token) {
+    return htmlPage('Geçersiz bağlantı', 'Onay bağlantısı eksik veya hatalı.', 400);
+  }
+
+  const tokenRecord = await kv.get(confirmationKey(token), 'json') as { emailHash?: string } | null;
+  if (!tokenRecord?.emailHash) {
+    return htmlPage('Bağlantı süresi doldu', 'Bu onay bağlantısı geçersiz veya süresi dolmuş.', 400);
+  }
+
+  const key = subscriberKey(tokenRecord.emailHash);
+  const subscriber = await kv.get(key, 'json') as SubscriberRecord | null;
+  if (!subscriber) {
+    await kv.delete(confirmationKey(token));
+    return htmlPage('Abonelik bulunamadı', 'Bu bağlantıya ait abonelik kaydı bulunamadı.', 404);
+  }
+
+  const now = new Date().toISOString();
+  const updated: SubscriberRecord = {
+    ...subscriber,
+    status: 'active',
+    confirmedAt: subscriber.confirmedAt ?? now,
+    unsubscribedAt: undefined,
+    updatedAt: now,
+  };
+
+  await kv.put(key, JSON.stringify(updated));
+  await kv.delete(confirmationKey(token));
+
+  return htmlPage('Abonelik onaylandı', 'Gündem Amerika bülten aboneliğiniz etkinleştirildi.');
+}

--- a/blog/src/pages/api/newsletter/send.ts
+++ b/blog/src/pages/api/newsletter/send.ts
@@ -1,0 +1,105 @@
+import type { APIContext } from 'astro';
+import { env } from 'cloudflare:workers';
+import {
+  getBaseUrl,
+  json,
+  sendDigestEmail,
+  SUBSCRIBER_PREFIX,
+  type EmailBinding,
+  type NewsletterPost,
+  type SubscriberRecord,
+} from '../../../lib/newsletter';
+
+export const prerender = false;
+
+function getKV(): KVNamespace | undefined {
+  return (env as any).VIDEO_QUEUE;
+}
+
+function getEmail(): EmailBinding | undefined {
+  return (env as any).EMAIL;
+}
+
+function isAuthorized(request: Request): boolean {
+  const configured = (env as any).NEWSLETTER_ADMIN_TOKEN;
+  if (typeof configured !== 'string' || configured.length < 16) return false;
+  return request.headers.get('authorization') === `Bearer ${configured}`;
+}
+
+function validatePosts(posts: unknown): NewsletterPost[] | null {
+  if (!Array.isArray(posts) || posts.length === 0 || posts.length > 10) return null;
+
+  const valid: NewsletterPost[] = [];
+  for (const post of posts) {
+    if (!post || typeof post !== 'object') return null;
+    const item = post as Record<string, unknown>;
+    if (typeof item.title !== 'string' || typeof item.url !== 'string') return null;
+    try {
+      const url = new URL(item.url);
+      if (url.hostname !== 'gundemamerika.com') return null;
+    } catch {
+      return null;
+    }
+    valid.push({
+      title: item.title.slice(0, 180),
+      url: item.url,
+      description: typeof item.description === 'string' ? item.description.slice(0, 260) : undefined,
+    });
+  }
+
+  return valid;
+}
+
+export async function POST(context: APIContext): Promise<Response> {
+  if (!isAuthorized(context.request)) {
+    return json({ error: 'Yetkisiz istek.' }, { status: 401 });
+  }
+
+  const kv = getKV();
+  const emailBinding = getEmail();
+  if (!kv || !emailBinding) {
+    return json({ error: 'Bülten servisi şu anda yapılandırılmamış.' }, { status: 503 });
+  }
+
+  let body: { subject?: unknown; posts?: unknown };
+  try {
+    body = await context.request.json();
+  } catch {
+    return json({ error: 'Geçersiz JSON.' }, { status: 400 });
+  }
+
+  const posts = validatePosts(body.posts);
+  if (!posts) {
+    return json({ error: 'Geçerli yazı listesi gerekli.' }, { status: 400 });
+  }
+
+  const subject = typeof body.subject === 'string' ? body.subject.slice(0, 120) : undefined;
+  const baseUrl = getBaseUrl(context.request);
+  let cursor: string | undefined;
+  let sent = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  do {
+    const list = await kv.list({ prefix: SUBSCRIBER_PREFIX, cursor, limit: 100 });
+    cursor = list.cursor;
+
+    for (const key of list.keys) {
+      const subscriber = await kv.get(key.name, 'json') as SubscriberRecord | null;
+      if (!subscriber || subscriber.status !== 'active') {
+        skipped++;
+        continue;
+      }
+
+      const unsubscribeUrl = `${baseUrl}/api/unsubscribe?token=${subscriber.unsubscribeToken}`;
+      try {
+        await sendDigestEmail(emailBinding, env as any, subscriber, posts, unsubscribeUrl, subject);
+        sent++;
+      } catch {
+        failed++;
+      }
+    }
+  } while (cursor);
+
+  return json({ sent, skipped, failed });
+}

--- a/blog/src/pages/api/subscribe.ts
+++ b/blog/src/pages/api/subscribe.ts
@@ -1,0 +1,89 @@
+import type { APIContext } from 'astro';
+import { env } from 'cloudflare:workers';
+import {
+  confirmationKey,
+  isValidEmail,
+  json,
+  getBaseUrl,
+  normalizeEmail,
+  parseEmailRequest,
+  randomToken,
+  rateKey,
+  sendConfirmationEmail,
+  sha256,
+  subscriberKey,
+  unsubscribeKey,
+  type EmailBinding,
+  type SubscriberRecord,
+} from '../../lib/newsletter';
+
+export const prerender = false;
+
+function getKV(): KVNamespace | undefined {
+  return (env as any).VIDEO_QUEUE;
+}
+
+function getEmail(): EmailBinding | undefined {
+  return (env as any).EMAIL;
+}
+
+export async function POST(context: APIContext): Promise<Response> {
+  const kv = getKV();
+  const emailBinding = getEmail();
+
+  if (!kv || !emailBinding) {
+    return json({ error: 'Bülten servisi şu anda yapılandırılmamış.' }, { status: 503 });
+  }
+
+  let rawEmail: string | null;
+  try {
+    rawEmail = await parseEmailRequest(context.request);
+  } catch {
+    return json({ error: 'Geçersiz istek.' }, { status: 400 });
+  }
+
+  const email = normalizeEmail(rawEmail ?? '');
+  if (!isValidEmail(email)) {
+    return json({ error: 'Geçerli bir e-posta adresi girin.' }, { status: 400 });
+  }
+
+  const emailHash = await sha256(email);
+  const limited = await kv.get(rateKey(emailHash));
+  if (limited) {
+    return json({ message: 'Onay e-postası gönderildiyse gelen kutunuzu kontrol edin.' });
+  }
+
+  await kv.put(rateKey(emailHash), '1', { expirationTtl: 300 });
+
+  const now = new Date().toISOString();
+  const existing = await kv.get(subscriberKey(emailHash), 'json') as SubscriberRecord | null;
+  if (existing?.status === 'active') {
+    return json({ message: 'Bu e-posta zaten bültene kayıtlı.' });
+  }
+
+  const unsubscribeToken = existing?.unsubscribeToken ?? randomToken();
+  const confirmToken = randomToken();
+  const subscriber: SubscriberRecord = {
+    email,
+    emailHash,
+    status: 'pending',
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+    confirmationSentAt: now,
+    unsubscribeToken,
+  };
+
+  await kv.put(subscriberKey(emailHash), JSON.stringify(subscriber));
+  await kv.put(confirmationKey(confirmToken), JSON.stringify({ emailHash }), { expirationTtl: 60 * 60 * 24 });
+  await kv.put(unsubscribeKey(unsubscribeToken), JSON.stringify({ emailHash }));
+
+  const confirmUrl = `${getBaseUrl(context.request)}/api/confirm?token=${confirmToken}`;
+  try {
+    await sendConfirmationEmail(emailBinding, env as any, subscriber, confirmUrl);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'E-posta gönderilemedi.';
+    return json({ error: message }, { status: 502 });
+  }
+
+  return json({ message: 'Onay e-postası gönderildi. Aboneliği tamamlamak için bağlantıya tıklayın.' });
+}

--- a/blog/src/pages/api/unsubscribe.ts
+++ b/blog/src/pages/api/unsubscribe.ts
@@ -1,0 +1,51 @@
+import type { APIContext } from 'astro';
+import { env } from 'cloudflare:workers';
+import {
+  htmlPage,
+  subscriberKey,
+  unsubscribeKey,
+  type SubscriberRecord,
+} from '../../lib/newsletter';
+
+export const prerender = false;
+
+function getKV(): KVNamespace | undefined {
+  return (env as any).VIDEO_QUEUE;
+}
+
+export async function GET(context: APIContext): Promise<Response> {
+  const kv = getKV();
+  if (!kv) {
+    return htmlPage('Bülten yapılandırılmamış', 'Bülten servisi şu anda kullanılamıyor.', 503);
+  }
+
+  const token = new URL(context.request.url).searchParams.get('token')?.trim();
+  if (!token) {
+    return htmlPage('Geçersiz bağlantı', 'Abonelikten çıkma bağlantısı eksik veya hatalı.', 400);
+  }
+
+  const tokenRecord = await kv.get(unsubscribeKey(token), 'json') as { emailHash?: string } | null;
+  if (!tokenRecord?.emailHash) {
+    return htmlPage('Bağlantı geçersiz', 'Bu abonelikten çıkma bağlantısı geçersiz.', 400);
+  }
+
+  const key = subscriberKey(tokenRecord.emailHash);
+  const subscriber = await kv.get(key, 'json') as SubscriberRecord | null;
+  if (!subscriber) {
+    await kv.delete(unsubscribeKey(token));
+    return htmlPage('Abonelik bulunamadı', 'Bu bağlantıya ait abonelik kaydı bulunamadı.', 404);
+  }
+
+  const now = new Date().toISOString();
+  const updated: SubscriberRecord = {
+    ...subscriber,
+    status: 'unsubscribed',
+    unsubscribedAt: now,
+    updatedAt: now,
+  };
+
+  await kv.put(key, JSON.stringify(updated));
+  await kv.delete(unsubscribeKey(token));
+
+  return htmlPage('Abonelikten çıkıldı', 'Gündem Amerika bülten aboneliğiniz iptal edildi.');
+}

--- a/blog/src/pages/gizlilik.astro
+++ b/blog/src/pages/gizlilik.astro
@@ -15,11 +15,22 @@ export const prerender = true;
       <h2>Toplanan Veriler</h2>
       <p>Gündem Amerika, kullanıcı gizliliğine önem verir. Sitemizde:</p>
       <ul>
-        <li><strong>Kişisel veri toplanmaz.</strong> Hesap oluşturma, giriş yapma veya form doldurma zorunluluğu yoktur.</li>
+        <li><strong>Bülten aboneliği isteğe bağlıdır.</strong> E-posta bültenine abone olursanız adresiniz abonelik onayı ve yeni yazı bildirimleri için saklanır.</li>
         <li><strong>Hesap çerezi kullanılmaz.</strong> Sitemiz giriş, üyelik veya yorum sistemi için çerez gerektirmez.</li>
         <li><strong>Üçüncü taraf çerezleri kullanılabilir.</strong> Google Analytics 4, Google AdSense ve gömülü medya hizmetleri reklam gösterimi, ölçüm, güvenlik ve kişiselleştirme için çerez veya benzer teknolojiler kullanabilir.</li>
         <li><strong>Cloudflare Analytics:</strong> Sayfanın performansını ölçmek için Cloudflare'in anonim, JavaScript gerektirmeyen analitiği kullanılabilir. Bu veriler kişisel bilgi içermez.</li>
       </ul>
+    </section>
+
+    <section>
+      <h2>E-posta Bülteni</h2>
+      <p>
+        Bültene abone olduğunuzda e-posta adresiniz Cloudflare altyapısındaki abonelik kaydında saklanır.
+        Abonelik çift onay bağlantısıyla etkinleşir ve her e-postada abonelikten çıkma bağlantısı bulunur.
+      </p>
+      <p>
+        E-posta adresiniz reklam hedefleme için kullanılmaz ve üçüncü taraflarla satılmaz.
+      </p>
     </section>
 
     <section>
@@ -73,6 +84,7 @@ export const prerender = true;
       <h2>Üçüncü Taraf Hizmetler</h2>
       <ul>
         <li><strong>Cloudflare:</strong> Site barındırma ve CDN hizmeti.</li>
+        <li><strong>Cloudflare Email Service:</strong> Bülten onay ve bildirim e-postalarının gönderimi.</li>
         <li><strong>GitHub:</strong> Kaynak kodu barındırma.</li>
         <li><strong>Google Analytics 4:</strong> Site trafiği ve kullanım ölçümü.</li>
         <li><strong>Google AdSense:</strong> Reklam gösterimi, ölçüm ve reklam güvenliği hizmetleri.</li>

--- a/blog/src/pages/hakkinda.astro
+++ b/blog/src/pages/hakkinda.astro
@@ -32,22 +32,23 @@ export const prerender = true;
       <ol>
         <li><strong>İzleme:</strong> Belirlenen YouTube kanalları ve playlistler saatlik olarak taranır.</li>
         <li><strong>Transkript:</strong> Video altyazıları otomatik olarak çekilir ve temizlenir.</li>
-        <li><strong>Çeviri:</strong> İçerik, Codex destekli yapay zekâ üretimiyle iki formatta Türkçe'ye çevrilir.</li>
+        <li><strong>Özet makale:</strong> İçerik, Codex destekli yapay zekâ üretimiyle kaynak metne sadık bir Türkçe haber özetine dönüştürülür.</li>
         <li><strong>Yayın:</strong> Çevrilen içerik otomatik olarak siteye yayınlanır.</li>
       </ol>
     </section>
 
     <section>
       <h2>İçerik Formatı</h2>
-      <p>Her yazı iki bölümden oluşur:</p>
+      <p>Yeni yazılar tek ana formatta yayımlanır:</p>
       <ul>
         <li><strong>Özet Makale (5-10 dk okuma):</strong> Podcast'in ana konularını, doğrudan alıntıları ve
         temel argümanları içeren gazetecilik formatında bir rapor. Kimin ne söylediğini hızlıca anlamak
         isteyen okuyucular için.</li>
-        <li><strong>Tam Çeviri (20-60 dk okuma):</strong> Podcast'in tamamının konuşmacı etiketleriyle
-        Türkçe çevirisi. Her paragrafın başında konuşmacının adı belirtilir. Tüm detayları okumak
-        isteyenler için.</li>
       </ul>
+      <p>
+        Eski arşiv yazılarında tam çeviri sekmesi bulunabilir. Yeni yayınlarda öncelik, daha kısa ama
+        kaynak metne sadık ve atıflı özet makalelerdir.
+      </p>
     </section>
 
     <section>
@@ -60,7 +61,8 @@ export const prerender = true;
         <li>Özel isimler orijinal İngilizce halleriyle korunur, ilk geçişte Türkçe açıklama eklenir.</li>
         <li>Deyimler anlam bazlı çevrilir, kelimesi kelimesine değil.</li>
         <li>Reklam ve sponsor bölümleri çeviriye dahil edilmez.</li>
-        <li>Her konuşmacının sözleri ayrı ayrı etiketlenir.</li>
+        <li>Tartışmalı iddialar konuşmacıya atfedilir; transkriptte bulunmayan bilgi eklenmez.</li>
+        <li>Belirsizlik, ihtimal ve iddia bildiren ifadeler Türkçe özet makalede korunur.</li>
       </ul>
       <p class="disclaimer">
         <strong>Önemli not:</strong> Bu bir otomatik çeviri platformudur. Yapay zekâ çevirileri yüksek

--- a/blog/src/pages/kullanim-sartlari.astro
+++ b/blog/src/pages/kullanim-sartlari.astro
@@ -15,7 +15,7 @@ export const prerender = true;
       <h2>İçerik Hakkında</h2>
       <p>
         Gündem Amerika'da yayınlanan içerikler, YouTube'da kamuya açık olarak yayınlanan podcast ve
-        haber programlarının Codex destekli yapay zekâ kullanılarak Türkçe'ye çevrilmiş halleridir.
+        haber programlarının Codex destekli yapay zekâ kullanılarak Türkçe hazırlanmış özet makaleleridir.
       </p>
       <p>
         Orijinal içerikler ilgili YouTube kanallarına ve içerik üreticilerine aittir. Gündem Amerika,
@@ -27,8 +27,8 @@ export const prerender = true;
     <section>
       <h2>Yapay Zekâ Çevirisi</h2>
       <p>
-        Tüm çeviriler otomatik olarak yapay zekâ tarafından gerçekleştirilmektedir. Çeviriler yüksek
-        kaliteli olmakla birlikte:
+        Tüm özet makaleler otomatik olarak yapay zekâ tarafından hazırlanmaktadır. Özetler kaynak
+        transkripte sadık olacak şekilde üretilse de:
       </p>
       <ul>
         <li>Hata, yanlış çeviri veya bağlam kaybı içerebilir.</li>

--- a/blog/wrangler.toml
+++ b/blog/wrangler.toml
@@ -4,3 +4,6 @@ compatibility_date = "2024-12-01"
 [[kv_namespaces]]
 binding = "VIDEO_QUEUE"
 id = "61de81ecc53742ed8edaffd69ebe3e4a"
+
+[[send_email]]
+name = "EMAIL"

--- a/pipeline/prompts/translate.md
+++ b/pipeline/prompts/translate.md
@@ -1,9 +1,13 @@
-You are a professional journalist and translator covering international politics and news for a Turkish-speaking audience. You will receive a podcast transcript; it may be in English, Arabic, Turkish, or another language. Identify the source language and translate the editorial content into Turkish. Produce all of the following sections.
+You are a professional journalist and translator covering international politics and news for a Turkish-speaking audience. You will receive a podcast transcript; it may be in English, Arabic, Turkish, or another language. Identify the source language and produce a source-faithful Turkish summary article and metadata. Produce only the sections listed below.
 
 IMPORTANT:
 - Return only the requested content sections. Do not include preambles, process notes, file names, or commentary about your work.
 - Skip all advertisements, sponsor reads, promotional segments, product placements, and calls to subscribe. Do not translate or include them in any section.
 - Use correct Turkish characters at all times: ü, ö, ç, ş, ı, ğ, İ.
+- Do not produce a full transcript translation. The article must stand on its own as an accurate, source-grounded news summary.
+- Accuracy is more important than elegance. Do not invent names, claims, dates, numbers, causal links, or background facts that are not in the transcript.
+- Preserve uncertainty. If a speaker says "maybe", "I think", "allegedly", or similar qualifiers, keep that qualification in Turkish.
+- Attribute disputed claims to the speaker. Do not present a speaker's claim as verified fact unless the transcript itself establishes it.
 
 ---SUMMARY_ARTICLE---
 Write a 1500-2000 word Turkish article faithfully reporting what was discussed in this podcast. Requirements:
@@ -29,19 +33,6 @@ Write a 1500-2000 word Turkish article faithfully reporting what was discussed i
   - "swing state" → "kararsız eyalet"
   - "primary" → "ön seçim"
 - For idioms, translate the meaning, for example "kicked the can down the road" → "sorunu erteledi".
-
----FULL_TRANSLATION---
-Complete Turkish translation of the entire editorial transcript. Paragraph by paragraph, preserving the full conversational flow. Use the same terminology rules as above. Structure into readable paragraphs with `##` section headers where the topic changes.
-
-CRITICAL: Clearly label who is speaking. Start every paragraph with the speaker's name in bold, followed by a colon, even if the same person continues speaking across multiple paragraphs. Every paragraph must begin with `**Speaker Name:**`. Example:
-
-**Tucker Carlson:** Bugün çok önemli bir konuğumuz var...
-
-**Avraham Burg:** Teşekkür ederim, burada olmaktan mutluluk duyuyorum...
-
-**Avraham Burg:** Bir şey daha eklemek istiyorum. Bu mesele çok derin...
-
-If you cannot identify the exact speaker, use descriptive labels like `**Sunucu:**` or `**Konuk:**`. Never leave any paragraph unattributed.
 
 ---TITLE---
 A concise, compelling Turkish title for this article in newspaper headline style. Always include the full name of the main speaker/guest in the title, not just their title or role. Example: "Eski MI6 Yetkilisi Shashank Joshi: ..." not just "Eski MI6 Yetkilisi: ..."

--- a/pipeline/src/formatter.ts
+++ b/pipeline/src/formatter.ts
@@ -26,7 +26,8 @@ export function slugifyGuest(name: string): string {
 }
 
 function estimateReadingTime(text: string): number {
-  const words = text.split(/\s+/).length;
+  const words = text.trim().split(/\s+/).filter(Boolean).length;
+  if (words === 0) return 0;
   return Math.max(1, Math.round(words / 200)); // ~200 words per minute for Turkish
 }
 
@@ -74,7 +75,12 @@ export function formatBlogPost(
     '---',
   ].join('\n');
 
-  return `${frontmatter}\n\n${translation.summaryArticle}\n\n<!-- FULL_TRANSLATION -->\n\n${translation.fullTranslation}\n`;
+  const fullTranslation = translation.fullTranslation.trim();
+  if (!fullTranslation) {
+    return `${frontmatter}\n\n${translation.summaryArticle}\n`;
+  }
+
+  return `${frontmatter}\n\n${translation.summaryArticle}\n\n<!-- FULL_TRANSLATION -->\n\n${fullTranslation}\n`;
 }
 
 export function formatThread(
@@ -130,7 +136,7 @@ export function writeBlogPost(
   updateVideoStatus(videoId, 'formatted', {
     translated_title: translation.title,
     summary_article: translation.summaryArticle,
-    full_translation: translation.fullTranslation,
+    full_translation: translation.fullTranslation.trim() || null,
     tags: JSON.stringify(translation.tags),
     guests: JSON.stringify(translation.guests),
     thread: JSON.stringify(translation.thread),

--- a/pipeline/src/translator.ts
+++ b/pipeline/src/translator.ts
@@ -6,15 +6,6 @@ import { resolvePromptPath } from './config.js';
 import { logger } from './logger.js';
 import type { Config, TranslationOutcome, TranslationResult } from './types.js';
 
-const SECTION_MARKERS = [
-  '---SUMMARY_ARTICLE---',
-  '---FULL_TRANSLATION---',
-  '---TITLE---',
-  '---GUESTS---',
-  '---TAGS---',
-  '---THREAD---',
-] as const;
-
 const SUMMARY_ONLY_MARKERS = [
   '---SUMMARY_ARTICLE---',
   '---TITLE---',
@@ -183,27 +174,6 @@ function parseSections(raw: string, markers: readonly string[]): Record<string, 
   return sections;
 }
 
-function parseStructuredOutput(raw: string): TranslationResult | null {
-  const sections = parseSections(raw, SECTION_MARKERS);
-  if (!sections) return null;
-
-  const guests = sections['---GUESTS---'];
-  const tags = sections['---TAGS---'];
-  const thread = sections['---THREAD---'];
-
-  return {
-    summaryArticle: sections['---SUMMARY_ARTICLE---'],
-    fullTranslation: sections['---FULL_TRANSLATION---'],
-    title: sections['---TITLE---'],
-    guests: guests === 'Yok' ? [] : parseCommaSeparated(guests),
-    tags: parseCommaSeparated(tags),
-    thread: thread
-      .split('\n')
-      .map((line) => line.replace(/^[-•*\d.)\s]+/, '').trim())
-      .filter((line) => line.length > 0),
-  };
-}
-
 // Extract comma-separated items from a section. Takes only the first line
 // (before any blank line or --- marker) and limits to 15 items max.
 function parseCommaSeparated(raw: string): string[] {
@@ -241,53 +211,44 @@ function wordCount(text: string): number {
   return text.split(/\s+/).filter(Boolean).length;
 }
 
-function chunkAtParagraphs(text: string, maxWords: number): string[] {
-  // Try splitting on paragraph breaks first
-  let segments = text.split(/\n\n+/);
-  let joiner = '\n\n';
+function attributedQuoteCount(text: string): number {
+  const attributionVerbs = 'diyen|dedi|belirtti|açıkladı|vurguladı|ekledi|savundu|ifade etti|değerlendirdi';
+  const quoteThenAttribution = new RegExp(`["“][^"”]{20,}["”][^\\n.]{0,180}\\b(${attributionVerbs})\\b`, 'gi');
+  const attributionThenQuote = new RegExp(`\\b(${attributionVerbs})\\b[^\\n.]{0,180}["“][^"”]{20,}["”]`, 'gi');
 
-  // If no paragraph breaks (common with YouTube transcripts), split on sentences
-  if (segments.length <= 1) {
-    segments = text.split(/(?<=[.!?])\s+/);
-    joiner = ' ';
-  }
-
-  // If still just one segment, force-split on word count
-  if (segments.length <= 1) {
-    const words = text.split(/\s+/);
-    const chunks: string[] = [];
-    for (let i = 0; i < words.length; i += maxWords) {
-      chunks.push(words.slice(i, i + maxWords).join(' '));
-    }
-    return chunks;
-  }
-
-  const chunks: string[] = [];
-  let current: string[] = [];
-  let currentWords = 0;
-
-  for (const seg of segments) {
-    const segWords = wordCount(seg);
-    if (currentWords + segWords > maxWords && current.length > 0) {
-      chunks.push(current.join(joiner));
-      current = [seg];
-      currentWords = segWords;
-    } else {
-      current.push(seg);
-      currentWords += segWords;
-    }
-  }
-
-  if (current.length > 0) {
-    chunks.push(current.join(joiner));
-  }
-
-  return chunks;
+  return (text.match(quoteThenAttribution) ?? []).length
+    + (text.match(attributionThenQuote) ?? []).length;
 }
 
-function getOverlapContext(previousTranslation: string, words: number): string {
-  const allWords = previousTranslation.split(/\s+/);
-  return allWords.slice(-words).join(' ');
+function validateSummaryResult(
+  result: Omit<TranslationResult, 'fullTranslation'>,
+  transcriptWords: number,
+): string | null {
+  const summaryWords = wordCount(result.summaryArticle);
+  const minWords = Math.min(900, Math.max(350, Math.round(transcriptWords * 0.18)));
+  const headingCount = (result.summaryArticle.match(/^##\s+/gm) ?? []).length;
+  const quoteAttributions = attributedQuoteCount(result.summaryArticle);
+
+  if (summaryWords < minWords) {
+    return `Summary article too short: ${summaryWords} words, expected at least ${minWords}`;
+  }
+  if (headingCount < 3 && transcriptWords > 1200) {
+    return `Summary article has too few section headers: ${headingCount}`;
+  }
+  if (quoteAttributions < 2 && transcriptWords > 1200) {
+    return `Summary article has too few attributed direct quotes: ${quoteAttributions}`;
+  }
+  if (!result.title || result.title.length < 12) {
+    return 'Title is missing or too short';
+  }
+  if (result.tags.length === 0) {
+    return 'Tags are missing';
+  }
+  if (result.thread.length < 5) {
+    return `Thread has too few points: ${result.thread.length}`;
+  }
+
+  return null;
 }
 
 export async function translate(
@@ -301,90 +262,32 @@ export async function translate(
 
   logger.info({ videoId, words, generator }, 'Starting translation');
 
-  // Single-pass works for shorter transcripts. For longer ones, the output
-  // (summary + full translation) becomes too large and times out.
-  // Threshold: ~6000 words input -> ~8000 words output is safe for single pass.
-  if (words <= 6000) {
-    const fullPrompt = `${systemPrompt}\n\n---TRANSCRIPT---\n${transcript}`;
-    const { stdout, stderr, exitCode } = await invokeArticleGenerator(fullPrompt, config.translation.timeoutSingleMs);
+  const fullPrompt = `${systemPrompt}\n\n---TRANSCRIPT---\n${transcript}`;
+  const { stdout, stderr, exitCode } = await invokeArticleGenerator(fullPrompt, config.translation.timeoutSingleMs);
 
-    if (exitCode === -1 && stderr.includes('ETIMEDOUT')) {
-      return { ok: false, error: 'timeout', details: `Timed out after ${config.translation.timeoutSingleMs}ms (${words} words)` };
-    }
-    if (exitCode !== 0) {
-      return { ok: false, error: 'cli_error', details: `Exit code ${exitCode}: ${stderr}` };
-    }
-
-    const result = parseStructuredOutput(stdout);
-    if (!result) {
-      return { ok: false, error: 'malformed_output', details: `Missing section markers in output (${stdout.length} chars)` };
-    }
-
-    logger.info({ videoId, generator, strategy: 'single' }, 'Translation complete');
-    return { ok: true, result };
+  if (exitCode === -1 && stderr.includes('ETIMEDOUT')) {
+    return { ok: false, error: 'timeout', details: `Timed out after ${config.translation.timeoutSingleMs}ms (${words} words)` };
+  }
+  if (exitCode !== 0) {
+    return { ok: false, error: 'cli_error', details: `Exit code ${exitCode}: ${stderr}` };
   }
 
-  // Two-pass: transcript too long
-  logger.info({ videoId, words, generator }, 'Transcript too long for single pass, using two-pass strategy');
-
-  // Pass 1: Summary + metadata (no full translation)
-  const pass1Prompt = `${systemPrompt}\n\nIMPORTANT: For this invocation, produce only these sections: ---SUMMARY_ARTICLE---, ---TITLE---, ---GUESTS---, ---TAGS---, ---THREAD---. Do NOT produce ---FULL_TRANSLATION---. Return only the requested content, with no preamble, process notes, or commentary.\n\n---TRANSCRIPT---\n${transcript}`;
-  const pass1 = await invokeArticleGenerator(pass1Prompt, config.translation.timeoutSingleMs);
-
-  if (pass1.exitCode === -1 && pass1.stderr.includes('ETIMEDOUT')) {
-    return { ok: false, error: 'timeout', details: `Pass 1 timed out (${words} words)` };
-  }
-  if (pass1.exitCode !== 0) {
-    return { ok: false, error: 'cli_error', details: `Pass 1 exit code ${pass1.exitCode}: ${pass1.stderr}` };
-  }
-
-  const summaryResult = parseSummaryOnlyOutput(pass1.stdout);
+  const summaryResult = parseSummaryOnlyOutput(stdout);
   if (!summaryResult) {
-    return { ok: false, error: 'malformed_output', details: `Pass 1: Missing section markers (${pass1.stdout.length} chars)` };
+    return { ok: false, error: 'malformed_output', details: `Missing summary-only section markers (${stdout.length} chars)` };
   }
 
-  // Pass 2: Chunked full translation
-  const chunks = chunkAtParagraphs(transcript, config.translation.chunkSize);
-  const translatedChunks: string[] = [];
-
-  for (let i = 0; i < chunks.length; i++) {
-    const chunk = chunks[i];
-    let chunkPrompt: string;
-
-    if (i === 0) {
-      chunkPrompt = `Translate the following podcast transcript excerpt to Turkish. Return only the Turkish translation content, with no preamble, process notes, or commentary. Structure into readable paragraphs with ## section headers where the topic changes. Clearly label speakers when identifiable. Keep proper nouns in English. Use established Turkish equivalents for US political terms.\n\n---TRANSCRIPT CHUNK ${i + 1}/${chunks.length}---\n${chunk}`;
-    } else {
-      const overlap = getOverlapContext(translatedChunks[i - 1], 200);
-      chunkPrompt = `Continue translating this podcast transcript to Turkish. Return only the Turkish translation content, with no preamble, process notes, or commentary. Maintain consistent terminology with the previous section. Previous translated section ended with:\n\n"${overlap}"\n\n---TRANSCRIPT CHUNK ${i + 1}/${chunks.length}---\n${chunk}`;
-    }
-
-    logger.info({ videoId, chunk: i + 1, total: chunks.length, generator }, 'Translating chunk');
-
-    const chunkResult = await invokeArticleGenerator(chunkPrompt, config.translation.timeoutChunkMs);
-
-    if (chunkResult.exitCode === -1 && chunkResult.stderr.includes('ETIMEDOUT')) {
-      return { ok: false, error: 'timeout', details: `Chunk ${i + 1}/${chunks.length} timed out` };
-    }
-    if (chunkResult.exitCode !== 0) {
-      return { ok: false, error: 'cli_error', details: `Chunk ${i + 1}/${chunks.length} exit ${chunkResult.exitCode}: ${chunkResult.stderr}` };
-    }
-
-    translatedChunks.push(chunkResult.stdout.trim());
-
-    // Delay between chunk invocations
-    if (i < chunks.length - 1) {
-      await new Promise((r) => setTimeout(r, config.translation.delayBetweenMs));
-    }
+  const validationError = validateSummaryResult(summaryResult, words);
+  if (validationError) {
+    return { ok: false, error: 'malformed_output', details: validationError };
   }
 
-  const fullTranslation = translatedChunks.join('\n\n');
-
-  logger.info({ videoId, generator, strategy: 'two_pass', chunks: chunks.length }, 'Translation complete');
+  logger.info({ videoId, generator, strategy: 'summary_only' }, 'Translation complete');
   return {
     ok: true,
     result: {
       ...summaryResult,
-      fullTranslation,
+      fullTranslation: '',
     },
   };
 }


### PR DESCRIPTION
## Summary

- Add a Cloudflare Email Service newsletter flow with footer signup, double opt-in confirmation, unsubscribe, and a protected digest send endpoint.
- Store subscriber records under newsletter-prefixed keys in the existing `VIDEO_QUEUE` KV binding.
- Stop future full-translation generation and make the pipeline summary-only while preserving old archive compatibility.
- Strengthen summary prompt and validation so `Özet Makale` output is source-faithful, attributed, structured, and long enough.

Closes #54

## Verification

- `npm run build --workspace blog`
- `npx tsc --noEmit -p pipeline/tsconfig.json`
- `git diff --check`
- Formatter smoke test: empty `fullTranslation` emits no `<!-- FULL_TRANSLATION -->` marker and sets `readingTime.full` to `0`.
- Generated Worker config includes `send_email` binding named `EMAIL`.

## Deployment Notes

- Configure Cloudflare Email Service sender/domain for `NEWSLETTER_FROM`.
- Add `NEWSLETTER_ADMIN_TOKEN` as a Worker secret before using `/api/newsletter/send`.
- Optional Worker vars/secrets: `NEWSLETTER_FROM`, `NEWSLETTER_REPLY_TO`, `PUBLIC_SITE_URL`.
