### PR TITLE
Move newsletter signup higher

### DIFF
--- a/blog/src/components/Footer.astro
+++ b/blog/src/components/Footer.astro
@@ -1,6 +1,4 @@
 ---
-import NewsletterSignup from './NewsletterSignup.astro';
-
 const year = new Date().getFullYear();
 ---
 
@@ -20,7 +18,6 @@ const year = new Date().getFullYear();
         <a href="/rss.xml">RSS</a>
         <a href="https://buymeacoffee.com/gundemamerika" target="_blank" rel="noopener noreferrer" class="donate-link">Destek Ol</a>
       </div>
-      <NewsletterSignup />
     </div>
     <div class="footer-bottom">
       <p>&copy; {year} Gündem Amerika. Orijinal içerikler ilgili YouTube kanallarına aittir.</p>

--- a/blog/src/components/NewsletterSignup.astro
+++ b/blog/src/components/NewsletterSignup.astro
@@ -1,19 +1,33 @@
+---
+interface Props {
+  id?: string;
+}
+
+const { id = 'newsletter-email' } = Astro.props;
+---
+
 <form class="newsletter-form" data-newsletter-form>
-  <label for="newsletter-email">Bültene abone olun</label>
-  <div class="newsletter-row">
-    <input
-      id="newsletter-email"
-      name="email"
-      type="email"
-      autocomplete="email"
-      inputmode="email"
-      placeholder="e-posta adresiniz"
-      required
-    />
-    <button type="submit">Abone ol</button>
+  <div class="newsletter-copy">
+    <span class="newsletter-kicker">Gündem bülteni</span>
+    <label for={id}>Yeni yazıları e-postayla alın</label>
+    <p>ABD gündeminden kaynaklı, kısa ve atıflı Türkçe özetler yayımlandığında haber verelim.</p>
   </div>
-  <p class="newsletter-note">Yeni yazılar için onay bağlantısı gönderilir.</p>
-  <p class="newsletter-message" data-newsletter-message aria-live="polite"></p>
+  <div class="newsletter-action">
+    <div class="newsletter-row">
+      <input
+        id={id}
+        name="email"
+        type="email"
+        autocomplete="email"
+        inputmode="email"
+        placeholder="e-posta adresiniz"
+        required
+      />
+      <button type="submit">Abone ol</button>
+    </div>
+    <p class="newsletter-note">Çift onaylıdır. Her e-postada abonelikten çıkma bağlantısı bulunur.</p>
+    <p class="newsletter-message" data-newsletter-message aria-live="polite"></p>
+  </div>
 </form>
 
 <script is:inline>
@@ -55,15 +69,52 @@
 
 <style>
   .newsletter-form {
-    min-width: min(100%, 340px);
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(320px, 0.85fr);
+    gap: 1.25rem;
+    align-items: center;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-top: 4px solid var(--color-accent);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-sm);
+    padding: 1.25rem;
+  }
+
+  .newsletter-copy {
+    min-width: 0;
+  }
+
+  .newsletter-kicker {
+    display: inline-block;
+    color: var(--color-accent);
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    margin-bottom: 0.25rem;
+    text-transform: uppercase;
   }
 
   label {
     display: block;
-    color: #f9fafb;
-    font-size: 0.82rem;
+    color: var(--color-text);
+    font-family: var(--font-serif);
+    font-size: 1.35rem;
     font-weight: 700;
-    margin-bottom: 0.5rem;
+    line-height: 1.2;
+    margin-bottom: 0.35rem;
+  }
+
+  .newsletter-copy p {
+    color: var(--color-text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.55;
+    margin: 0;
+    max-width: 48ch;
+  }
+
+  .newsletter-action {
+    min-width: 0;
   }
 
   .newsletter-row {
@@ -74,17 +125,23 @@
   input {
     min-width: 0;
     flex: 1;
-    border: 1px solid #374151;
+    border: 1px solid var(--color-border);
     border-radius: 4px;
-    background: #111827;
-    color: #f9fafb;
+    background: var(--color-bg);
+    color: var(--color-text);
     font: inherit;
     font-size: 0.85rem;
-    padding: 0.55rem 0.65rem;
+    padding: 0.65rem 0.75rem;
   }
 
   input::placeholder {
-    color: #6b7280;
+    color: var(--color-text-muted);
+  }
+
+  input:focus {
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 3px var(--color-accent-light);
+    outline: none;
   }
 
   button {
@@ -96,7 +153,7 @@
     font: inherit;
     font-size: 0.82rem;
     font-weight: 700;
-    padding: 0.55rem 0.8rem;
+    padding: 0.65rem 0.95rem;
     white-space: nowrap;
   }
 
@@ -113,12 +170,24 @@
   }
 
   .newsletter-note {
-    color: #9ca3af;
+    color: var(--color-text-muted);
   }
 
   .newsletter-message {
-    color: #f9fafb;
+    color: var(--color-text-secondary);
     min-height: 1rem;
+  }
+
+  @media (max-width: 720px) {
+    .newsletter-form {
+      grid-template-columns: 1fr;
+      gap: 1rem;
+      padding: 1rem;
+    }
+
+    label {
+      font-size: 1.15rem;
+    }
   }
 
   @media (max-width: 420px) {

--- a/blog/src/layouts/PostLayout.astro
+++ b/blog/src/layouts/PostLayout.astro
@@ -8,6 +8,7 @@ import Breadcrumbs from '../components/Breadcrumbs.astro';
 import SourceAttribution from '../components/SourceAttribution.astro';
 import RelatedPosts from '../components/RelatedPosts.astro';
 import TableOfContents from '../components/TableOfContents.astro';
+import NewsletterSignup from '../components/NewsletterSignup.astro';
 import { channelSlug } from '../lib/slugs';
 
 interface Props {
@@ -141,6 +142,10 @@ const jsonLd = {
         <a href="https://buymeacoffee.com/gundemamerika" target="_blank" rel="noopener noreferrer" class="support-btn">Destek Ol</a>
       </div>
     </article>
+
+    <section class="post-newsletter" aria-label="E-posta bülteni">
+      <NewsletterSignup id={`post-newsletter-${videoId}`} />
+    </section>
 
     <RelatedPosts currentId={post.id} tags={tags} allPosts={allPosts} />
   </main>
@@ -370,6 +375,10 @@ const jsonLd = {
     background: #FFE84D;
     color: #000;
     text-decoration: none;
+  }
+
+  .post-newsletter {
+    margin: 2rem 0 0;
   }
 
   .feedback-row {

--- a/blog/src/lib/newsletter.ts
+++ b/blog/src/lib/newsletter.ts
@@ -101,6 +101,54 @@ function escapeHtml(value: string): string {
     .replace(/'/g, '&#039;');
 }
 
+function renderEmailLayout(options: {
+  preheader: string;
+  title: string;
+  lede: string;
+  contentHtml: string;
+  footerHtml?: string;
+}): string {
+  return `<!doctype html>
+<html lang="tr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(options.title)} | Gündem Amerika</title>
+</head>
+<body style="margin:0;padding:0;background:#f8f9fa;color:#111827;font-family:Inter,Arial,sans-serif;">
+  <div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent;">${escapeHtml(options.preheader)}</div>
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f8f9fa;padding:28px 12px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:620px;background:#ffffff;border:1px solid #e5e7eb;border-top:5px solid #dc2626;border-radius:8px;overflow:hidden;">
+          <tr>
+            <td style="padding:24px 24px 14px;border-bottom:1px solid #e5e7eb;">
+              <div style="font-size:18px;font-weight:800;letter-spacing:-0.02em;line-height:1;">
+                <span style="color:#dc2626;">GÜNDEM</span><span style="color:#111827;">AMERİKA</span>
+              </div>
+              <div style="margin-top:8px;color:#6b7280;font-size:13px;line-height:1.5;">ABD gündemine dair Türkçe özet makaleler</div>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:24px;">
+              <h1 style="margin:0 0 10px;font-family:Georgia,'Times New Roman',serif;color:#111827;font-size:28px;line-height:1.2;">${escapeHtml(options.title)}</h1>
+              <p style="margin:0 0 20px;color:#4b5563;font-size:15px;line-height:1.65;">${escapeHtml(options.lede)}</p>
+              ${options.contentHtml}
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:18px 24px;background:#111827;color:#9ca3af;font-size:12px;line-height:1.6;">
+              ${options.footerHtml ?? '<p style="margin:0;">Bu e-posta Gündem Amerika bülten aboneliğinizle ilgilidir.</p>'}
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}
+
 export async function parseEmailRequest(request: Request): Promise<string | null> {
   const contentType = request.headers.get('content-type') ?? '';
 
@@ -160,9 +208,16 @@ export async function sendConfirmationEmail(
 ): Promise<void> {
   const from = getSender(runtimeEnv);
   const replyTo = getReplyTo(runtimeEnv);
-  const html = `<p>Gündem Amerika bültenine aboneliğinizi onaylamak için aşağıdaki bağlantıya tıklayın:</p>
-<p><a href="${escapeHtml(confirmUrl)}">${escapeHtml(confirmUrl)}</a></p>
-<p>Bu isteği siz başlatmadıysanız bu e-postayı yok sayabilirsiniz.</p>`;
+  const safeConfirmUrl = escapeHtml(confirmUrl);
+  const html = renderEmailLayout({
+    preheader: 'Gündem Amerika bülten aboneliğinizi onaylayın.',
+    title: 'Bülten aboneliğinizi onaylayın',
+    lede: 'Yeni özet makaleler yayımlandığında e-postayla haber almak için aboneliğinizi tamamlayın.',
+    contentHtml: `<p style="margin:0 0 22px;color:#4b5563;font-size:15px;line-height:1.65;">Bu isteği siz başlattıysanız aşağıdaki bağlantıyla aboneliği etkinleştirebilirsiniz.</p>
+<p style="margin:0 0 22px;"><a href="${safeConfirmUrl}" style="display:inline-block;background:#dc2626;color:#ffffff;text-decoration:none;font-weight:700;font-size:14px;padding:12px 18px;border-radius:4px;">Aboneliği onayla</a></p>
+<p style="margin:0;color:#6b7280;font-size:12px;line-height:1.6;">Buton çalışmazsa bu bağlantıyı tarayıcınızda açın:<br><a href="${safeConfirmUrl}" style="color:#dc2626;word-break:break-all;">${safeConfirmUrl}</a></p>`,
+    footerHtml: '<p style="margin:0;">Bu isteği siz başlatmadıysanız bu e-postayı yok sayabilirsiniz.</p>',
+  });
   const text = `Gündem Amerika bültenine aboneliğinizi onaylamak için bağlantıyı açın:\n\n${confirmUrl}\n\nBu isteği siz başlatmadıysanız bu e-postayı yok sayabilirsiniz.`;
 
   await emailBinding.send({
@@ -185,18 +240,28 @@ export async function sendDigestEmail(
 ): Promise<void> {
   const from = getSender(runtimeEnv);
   const replyTo = getReplyTo(runtimeEnv);
-  const itemsHtml = posts.map((post) => `<li>
-  <a href="${escapeHtml(post.url)}">${escapeHtml(post.title)}</a>
-  ${post.description ? `<br><span>${escapeHtml(post.description)}</span>` : ''}
-</li>`).join('');
+  const itemsHtml = posts.map((post) => `<article style="border-top:1px solid #e5e7eb;padding:16px 0;">
+  <h2 style="margin:0 0 8px;font-size:18px;line-height:1.35;color:#111827;"><a href="${escapeHtml(post.url)}" style="color:#111827;text-decoration:none;">${escapeHtml(post.title)}</a></h2>
+  ${post.description ? `<p style="margin:0 0 12px;color:#4b5563;font-size:14px;line-height:1.6;">${escapeHtml(post.description)}</p>` : ''}
+  <a href="${escapeHtml(post.url)}" style="color:#dc2626;font-size:13px;font-weight:700;text-decoration:none;">Yazıyı oku</a>
+</article>`).join('');
   const itemsText = posts.map((post) => `- ${post.title}\n  ${post.url}${post.description ? `\n  ${post.description}` : ''}`).join('\n\n');
+  const safeUnsubscribeUrl = escapeHtml(unsubscribeUrl);
+  const html = renderEmailLayout({
+    preheader: 'Gündem Amerika’da yeni yazılar yayımlandı.',
+    title: 'Yeni yazılar',
+    lede: 'ABD gündemindeki son podcast ve haber programlarından hazırlanan Türkçe özetler.',
+    contentHtml: itemsHtml,
+    footerHtml: `<p style="margin:0 0 8px;">Gündem Amerika bültenine kayıtlı olduğunuz için gönderildi.</p>
+<p style="margin:0;"><a href="${safeUnsubscribeUrl}" style="color:#fca5a5;">Abonelikten çık</a></p>`,
+  });
 
   await emailBinding.send({
     to: subscriber.email,
     from,
     replyTo,
     subject,
-    html: `<p>Gündem Amerika'da yeni yazılar yayımlandı:</p><ul>${itemsHtml}</ul><p><a href="${escapeHtml(unsubscribeUrl)}">Abonelikten çık</a></p>`,
+    html,
     text: `Gündem Amerika'da yeni yazılar yayımlandı:\n\n${itemsText}\n\nAbonelikten çık: ${unsubscribeUrl}`,
     headers: {
       'List-Unsubscribe': `<${unsubscribeUrl}>`,

--- a/blog/src/pages/index.astro
+++ b/blog/src/pages/index.astro
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+import NewsletterSignup from '../components/NewsletterSignup.astro';
 import PostCard from '../components/PostCard.astro';
 import SearchBar from '../components/SearchBar.astro';
 import { channelSlug } from '../lib/slugs';
@@ -55,6 +56,12 @@ const otherPosts = posts.slice(1);
               readingTime={featuredPost.data.readingTime}
               featured={true}
             />
+          </div>
+        </section>
+
+        <section class="newsletter-section" aria-label="E-posta bülteni">
+          <div class="container">
+            <NewsletterSignup id="home-newsletter-email" />
           </div>
         </section>
 
@@ -124,6 +131,10 @@ const otherPosts = posts.slice(1);
 
   .hero-section {
     padding: 2rem 0 1rem;
+  }
+
+  .newsletter-section {
+    padding: 0.75rem 0 1.25rem;
   }
 
   .hero-grid {


### PR DESCRIPTION
## Summary

- Move the newsletter signup from the footer to a higher homepage placement.
- Add the signup after article content so mobile readers do not hit more pre-article clutter.
- Restyle the form and newsletter emails to match the Gündem Amerika editorial design.

## Test plan

- `git diff --check`
- `PATH=/Users/tugrultasgetiren/.nvm/versions/node/v25.2.1/bin:$PATH npx tsc --noEmit` from `pipeline/`
- `PATH=/Users/tugrultasgetiren/.nvm/versions/node/v25.2.1/bin:$PATH npm run build --workspace blog`
- Confirm built homepage and article HTML include the new newsletter placements.

Closes #58
