### PR TITLE
Fix mobile article metadata flow

### DIFF
--- a/blog/src/components/PostMeta.astro
+++ b/blog/src/components/PostMeta.astro
@@ -1,22 +1,24 @@
 ---
-import { channelSlug, tagSlug } from '../lib/slugs';
+import { tagSlug } from '../lib/slugs';
 
 interface Props {
-  channel: string;
   date: Date;
   guests: string[];
   tags: string[];
   readingTime: { summary: number; full: number };
 }
 
-const { channel, date, guests, tags, readingTime } = Astro.props;
+const { date, guests, tags, readingTime } = Astro.props;
 const formattedDate = date.toLocaleDateString('tr-TR', { year: 'numeric', month: 'long', day: 'numeric' });
 const hasFullTranslation = readingTime.full > 0;
+const visibleGuests = guests.slice(0, 3);
+const hiddenGuestCount = Math.max(guests.length - visibleGuests.length, 0);
+const visibleTags = tags.slice(0, 4);
+const hiddenTagCount = Math.max(tags.length - visibleTags.length, 0);
 ---
 
 <div class="post-meta">
-  <div class="meta-row">
-    <a href={`/kanal/${channelSlug(channel)}`} class="channel">{channel}</a>
+  <div class="meta-row meta-summary">
     <time datetime={date.toISOString()}>{formattedDate}</time>
     <span class="reading-time">
       Özet makale: {readingTime.summary} dk
@@ -24,21 +26,24 @@ const hasFullTranslation = readingTime.full > 0;
     </span>
   </div>
   {guests.length > 0 && (
-    <div class="meta-row guests">
+    <div class="meta-row guests" aria-label={`Konuklar: ${guests.join(', ')}`}>
       <span class="label">Konuklar:</span>
-      {guests.map((guest, i) => (
-        <>
-          <a href={`/konuk/${guest.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}`}>{guest}</a>
-          {i < guests.length - 1 && ', '}
-        </>
+      <span class="compact-list">
+      {visibleGuests.map((guest) => (
+        <a href={`/konuk/${guest.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}`}>{guest}</a>
       ))}
+      {hiddenGuestCount > 0 && <span class="more-count">+{hiddenGuestCount}</span>}
+      </span>
     </div>
   )}
-  <div class="meta-row tags-row">
-    {tags.map((tag) => (
+  {tags.length > 0 && (
+  <div class="meta-row tags-row" aria-label={`Etiketler: ${tags.join(', ')}`}>
+    {visibleTags.map((tag) => (
       <a href={`/etiket/${tagSlug(tag)}`} class="tag">{tag}</a>
     ))}
+    {hiddenTagCount > 0 && <span class="tag more-count">+{hiddenTagCount}</span>}
   </div>
+  )}
 </div>
 
 <style>
@@ -46,29 +51,35 @@ const hasFullTranslation = readingTime.full > 0;
     font-family: var(--font-sans);
     font-size: 0.85rem;
     color: var(--color-text-muted);
-    margin-bottom: 2rem;
-    padding-bottom: 1rem;
+    margin-bottom: 1.25rem;
+    padding-bottom: 0.85rem;
     border-bottom: 1px solid var(--color-border);
   }
 
   .meta-row {
-    margin-bottom: 0.4rem;
+    margin-bottom: 0.45rem;
     display: flex;
     flex-wrap: wrap;
-    gap: 0.75rem;
+    gap: 0.55rem;
     align-items: center;
   }
 
-  .channel {
-    font-weight: 600;
-    color: var(--color-accent);
+  .meta-summary {
+    column-gap: 0.75rem;
   }
 
   .label {
     color: var(--color-text-muted);
   }
 
-  .guests a {
+  .compact-list {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.35rem 0.6rem;
+    min-width: 0;
+  }
+
+  .compact-list a {
     color: var(--color-text);
   }
 
@@ -77,7 +88,8 @@ const hasFullTranslation = readingTime.full > 0;
     margin-top: 0.5rem;
   }
 
-  .tag {
+  .tag,
+  .more-count {
     font-size: 0.75rem;
     padding: 0.15rem 0.5rem;
     background: var(--color-bg);
@@ -85,8 +97,51 @@ const hasFullTranslation = readingTime.full > 0;
     color: var(--color-text-muted);
   }
 
+  .more-count {
+    display: inline-flex;
+    align-items: center;
+    font-family: var(--font-sans);
+    font-weight: 600;
+  }
+
   .tag:hover {
     background: var(--color-border);
     text-decoration: none;
+  }
+
+  @media (max-width: 640px) {
+    .post-meta {
+      margin-bottom: 1rem;
+      padding-bottom: 0.75rem;
+      font-size: 0.8rem;
+    }
+
+    .meta-row {
+      margin-bottom: 0.35rem;
+    }
+
+    .guests {
+      align-items: flex-start;
+      gap: 0.35rem 0.5rem;
+    }
+
+    .guests .label {
+      flex: 0 0 auto;
+    }
+
+    .compact-list {
+      gap: 0.25rem 0.5rem;
+      flex: 1 1 12rem;
+    }
+
+    .tags-row {
+      gap: 0.35rem;
+      margin-top: 0.35rem;
+    }
+
+    .tag,
+    .more-count {
+      font-size: 0.7rem;
+    }
   }
 </style>

--- a/blog/src/layouts/PostLayout.astro
+++ b/blog/src/layouts/PostLayout.astro
@@ -76,38 +76,16 @@ const jsonLd = {
     ]} />
 
     <article>
-      <a href={`/kanal/${channelSlug(channel)}`} class="hero-channel">{channel}</a>
-      <h1>{title}</h1>
+      <div class="article-intro">
+        <a href={`/kanal/${channelSlug(channel)}`} class="hero-channel">{channel}</a>
+        <h1>{title}</h1>
 
-      <PostMeta
-        channel={channel}
-        date={date}
-        guests={guests}
-        tags={tags}
-        readingTime={readingTime}
-      />
-
-      <!-- YouTube embed -->
-      <div class="video-embed">
-        <iframe
-          src={`https://www.youtube.com/embed/${videoId}?cc_lang_pref=tr&cc_load_policy=1&hl=tr`}
-          title={title}
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowfullscreen
-          loading="lazy"
-        ></iframe>
-      </div>
-
-      <!-- Table of Contents (#6) -->
-      <TableOfContents html={summaryHtml} />
-
-      <!-- Share buttons (#2) -->
-      <div class="share-bar">
-        <span class="share-label">Paylaş:</span>
-        <a href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodeURIComponent(`https://gundemamerika.com/yazilar/${post.id}`)}`} target="_blank" rel="noopener noreferrer" class="share-btn share-x" aria-label="X'te paylaş"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg><span>X</span></a>
-        <a href={`https://api.whatsapp.com/send?text=${encodeURIComponent(title + ' ' + `https://gundemamerika.com/yazilar/${post.id}`)}`} target="_blank" rel="noopener noreferrer" class="share-btn share-wa" aria-label="WhatsApp'ta paylaş"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"/></svg><span>WhatsApp</span></a>
-        <a href={`https://t.me/share/url?url=${encodeURIComponent(`https://gundemamerika.com/yazilar/${post.id}`)}&text=${encodeURIComponent(title)}`} target="_blank" rel="noopener noreferrer" class="share-btn share-tg" aria-label="Telegram'da paylaş"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M11.944 0A12 12 0 000 12a12 12 0 0012 12 12 12 0 0012-12A12 12 0 0012 0a12 12 0 00-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 01.171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.479.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/></svg><span>Telegram</span></a>
-        <button type="button" id="copy-link-btn" class="share-btn share-copy" aria-label="Linki kopyala"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/></svg><span>Kopyala</span></button>
+        <PostMeta
+          date={date}
+          guests={guests}
+          tags={tags}
+          readingTime={readingTime}
+        />
       </div>
 
       {fullTranslationHtml && (
@@ -129,7 +107,34 @@ const jsonLd = {
         <section class="tab-content" id="tab-full" set:html={fullTranslationHtml} />
       )}
 
-      <SourceAttribution source={source} channel={channel} />
+      <div class="article-media">
+        <!-- YouTube embed -->
+        <div class="video-embed">
+          <iframe
+            src={`https://www.youtube.com/embed/${videoId}?cc_lang_pref=tr&cc_load_policy=1&hl=tr`}
+            title={title}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowfullscreen
+            loading="lazy"
+          ></iframe>
+        </div>
+
+        <!-- Table of Contents (#6) -->
+        <TableOfContents html={summaryHtml} />
+
+        <!-- Share buttons (#2) -->
+        <div class="share-bar">
+          <span class="share-label">Paylaş:</span>
+          <a href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodeURIComponent(`https://gundemamerika.com/yazilar/${post.id}`)}`} target="_blank" rel="noopener noreferrer" class="share-btn share-x" aria-label="X'te paylaş"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg><span>X</span></a>
+          <a href={`https://api.whatsapp.com/send?text=${encodeURIComponent(title + ' ' + `https://gundemamerika.com/yazilar/${post.id}`)}`} target="_blank" rel="noopener noreferrer" class="share-btn share-wa" aria-label="WhatsApp'ta paylaş"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"/></svg><span>WhatsApp</span></a>
+          <a href={`https://t.me/share/url?url=${encodeURIComponent(`https://gundemamerika.com/yazilar/${post.id}`)}&text=${encodeURIComponent(title)}`} target="_blank" rel="noopener noreferrer" class="share-btn share-tg" aria-label="Telegram'da paylaş"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M11.944 0A12 12 0 000 12a12 12 0 0012 12 12 12 0 0012-12A12 12 0 0012 0a12 12 0 00-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 01.171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.479.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/></svg><span>Telegram</span></a>
+          <button type="button" id="copy-link-btn" class="share-btn share-copy" aria-label="Linki kopyala"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/></svg><span>Kopyala</span></button>
+        </div>
+      </div>
+
+      <div class="article-source">
+        <SourceAttribution source={source} channel={channel} />
+      </div>
 
       <!-- Feedback + Support -->
       <div class="support-cta">
@@ -240,6 +245,35 @@ const jsonLd = {
     max-width: var(--content-width);
     margin: 0 auto;
     padding: 1.5rem 1.5rem 2rem;
+  }
+
+  article {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .article-intro {
+    order: 1;
+  }
+
+  .article-media {
+    order: 2;
+  }
+
+  .content-tabs {
+    order: 3;
+  }
+
+  .tab-content {
+    order: 4;
+  }
+
+  .article-source {
+    order: 5;
+  }
+
+  .support-cta {
+    order: 6;
   }
 
   /* Channel badge */
@@ -534,6 +568,39 @@ const jsonLd = {
   }
 
   @media (max-width: 640px) {
+    .post-page {
+      padding: 1rem 1.25rem 2rem;
+    }
+
+    .content-tabs {
+      order: 2;
+      position: static;
+      padding-top: 0;
+      margin-bottom: 1.25rem;
+      border-bottom-width: 1px;
+    }
+
+    .tab-content {
+      order: 3;
+    }
+
+    .article-media {
+      order: 4;
+      margin-top: 1.25rem;
+    }
+
+    .article-media :global(.toc) {
+      display: none;
+    }
+
+    .article-source {
+      order: 5;
+    }
+
+    .support-cta {
+      order: 6;
+    }
+
     article h1 {
       font-size: 1.5rem;
     }


### PR DESCRIPTION
## Summary

- Compact long guest and tag metadata on article pages so mobile readers reach the article sooner.
- Reorder mobile article pages so the summary/full text appears before video, contents, and share controls.
- Keep full metadata available through accessibility labels and preserve desktop media-first ordering.

Closes #62

## Test plan

- `npx tsc --noEmit` in `pipeline/`
- `npx astro build` in `blog/`
- `git diff --check`

## Blueprint

Blueprint review: APPROVE. Scope is limited to article layout components and does not change pipeline behavior, generated content, canonical URLs, or schema.
