### PR TITLE
Fix pipeline blog path resolution

### DIFF
--- a/ops/launchagents/com.amerikagundemi.pipeline.plist
+++ b/ops/launchagents/com.amerikagundemi.pipeline.plist
@@ -7,7 +7,7 @@
   <key>ProgramArguments</key>
   <array>
     <string>/bin/bash</string>
-    <string>/Users/tugrultasgetiren/bin/amerikagundemi-pipeline</string>
+    <string>/Volumes/Crucial X10/Claude Code Projects/AmerikaGundemi/run-pipeline.sh</string>
   </array>
   <key>StartCalendarInterval</key>
   <dict>

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "start": "tsx src/index.ts",
-    "dev": "tsx watch src/index.ts"
+    "dev": "tsx watch src/index.ts",
+    "test": "tsx --test src/config.test.ts"
   },
   "dependencies": {
     "better-sqlite3": "^11.0.0",

--- a/pipeline/src/config.test.ts
+++ b/pipeline/src/config.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import test from 'node:test';
+import { PROJECT_ROOT, resolveBlogRepoPath } from './config.js';
+
+test('resolves a relative blog repo path from the project root', () => {
+  const originalCwd = process.cwd();
+  const unrelatedCwd = mkdtempSync(join(tmpdir(), 'amerikagundemi-config-'));
+
+  try {
+    process.chdir(unrelatedCwd);
+    assert.equal(resolveBlogRepoPath('./blog'), resolve(PROJECT_ROOT, 'blog'));
+  } finally {
+    process.chdir(originalCwd);
+    rmSync(unrelatedCwd, { recursive: true, force: true });
+  }
+});
+
+test('preserves an absolute blog repo path', () => {
+  const absolutePath = resolve(tmpdir(), 'amerikagundemi-blog');
+  assert.equal(resolveBlogRepoPath(absolutePath), absolutePath);
+});

--- a/pipeline/src/config.ts
+++ b/pipeline/src/config.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { isAbsolute, resolve } from 'node:path';
 import type { Config } from './types.js';
 
 const PROJECT_ROOT = resolve(import.meta.dirname, '..', '..');
@@ -18,6 +18,10 @@ export function resolveDbPath(dbPath: string): string {
 
 export function resolvePromptPath(promptFile: string): string {
   return resolve(PROJECT_ROOT, promptFile);
+}
+
+export function resolveBlogRepoPath(repoPath: string): string {
+  return isAbsolute(repoPath) ? repoPath : resolve(PROJECT_ROOT, repoPath);
 }
 
 export { PROJECT_ROOT };

--- a/pipeline/src/formatter.ts
+++ b/pipeline/src/formatter.ts
@@ -1,5 +1,6 @@
 import { existsSync, writeFileSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { resolveBlogRepoPath } from './config.js';
 import { updateVideoStatus } from './db.js';
 import { logger } from './logger.js';
 import type { Config, TranslationResult } from './types.js';
@@ -120,7 +121,7 @@ export function writeBlogPost(
   config: Config,
 ): string {
   const slug = slugify(translation.title);
-  const postsDir = resolve(config.blog.repoPath, 'src', 'content', 'posts');
+  const postsDir = resolve(resolveBlogRepoPath(config.blog.repoPath), 'src', 'content', 'posts');
   const filePath = resolve(postsDir, `${slug}.md`);
 
   // Idempotent: skip if file already exists


### PR DESCRIPTION
## Summary

- resolve relative blog repository paths against the pipeline project root
- make generated-post formatting independent of the LaunchAgent working directory
- point the LaunchAgent template at the canonical wrapper and add regression coverage

## Test plan

- `cd pipeline && npm test`
- `cd pipeline && npx tsc --noEmit`
- `bash -n run-pipeline.sh`
- `plutil -lint ops/launchagents/com.amerikagundemi.pipeline.plist`
- `cd blog && npx astro build`
- `git diff --check`

Closes #64