### PR TITLE
Türkçe coğrafi ad kullanımını düzelt

### DIFF
--- a/blog/src/content/posts/s-muhammad-marande-abd-nin-muttefiklerini-cezalandiran-politikasi-west-asia-daki-gerilimi-buyutuyor.md
+++ b/blog/src/content/posts/s-muhammad-marande-abd-nin-muttefiklerini-cezalandiran-politikasi-west-asia-daki-gerilimi-buyutuyor.md
@@ -1,11 +1,11 @@
 ---
-title: "S. Muhammad Marande: ABD’nin Müttefiklerini Cezalandıran Politikası West Asia’daki Gerilimi Büyütüyor"
+title: "S. Muhammad Marande: ABD’nin Müttefiklerini Cezalandıran Politikası Batı Asya’daki Gerilimi Büyütüyor"
 date: 2026-08-01
 source: "https://www.youtube.com/watch?v=a56OhnHREY4"
 channel: "Glenn Diesen"
 videoId: "a56OhnHREY4"
-description: "İngilizce yayımlanan bölümde, Tehran University profesörü ve İran’ın nükleer müzakere heyetinin eski danışmanı S. Muhammad Marande, sunucu Glenn ile ABD’nin İspanya, İran ve West Asia’daki müttefiklerine yönelik politikalarını konuştu."
-tags: ["İran","ABD dış politikası","Israel","West Asia","İspanya","Morocco","Hürmüz Boğazı","Saudi Arabia","Jordan","Yemen","küresel güç mücadelesi"]
+description: "İngilizce yayımlanan bölümde, Tahran Üniversitesi profesörü ve İran’ın nükleer müzakere heyetinin eski danışmanı S. Muhammad Marande, sunucu Glenn ile ABD’nin İspanya, İran ve Batı Asya’daki müttefiklerine yönelik politikalarını konuştu."
+tags: ["İran","ABD dış politikası","İsrail","Batı Asya","İspanya","Fas","Hürmüz Boğazı","Suudi Arabistan","Ürdün","Yemen","küresel güç mücadelesi"]
 guests: ["S. Muhammad Marande","Glenn","Donald Trump","Benjamin Netanyahu","Tucker Carlson"]
 category: "siyaset"
 readingTime:
@@ -13,51 +13,51 @@ readingTime:
   full: 0
 ---
 
-İngilizce yayımlanan bölümde, Tehran University profesörü ve İran’ın nükleer müzakere heyetinin eski danışmanı S. Muhammad Marande, sunucu Glenn ile ABD’nin İspanya, İran ve West Asia’daki müttefiklerine yönelik politikalarını konuştu. Tartışma; Kuzey Afrika’daki İspanyol toprağına kitlesel geçiş iddiasından Saudi Arabia’nın nükleer programına, Hürmüz Boğazı’ndaki gerilimden İran’a yönelik saldırı tehditlerine kadar uzandı.
+İngilizce yayımlanan bölümde, Tahran Üniversitesi profesörü ve İran’ın nükleer müzakere heyetinin eski danışmanı S. Muhammad Marande, sunucu Glenn ile ABD’nin İspanya, İran ve Batı Asya’daki müttefiklerine yönelik politikalarını konuştu. Tartışma; Kuzey Afrika’daki İspanyol toprağına kitlesel geçiş iddiasından Suudi Arabistan’ın nükleer programına, Hürmüz Boğazı’ndaki gerilimden İran’a yönelik saldırı tehditlerine kadar uzandı.
 
-## İspanya sınırındaki kitlesel geçiş ve Morocco iddiası
+## İspanya sınırındaki kitlesel geçiş ve Fas iddiası
 
-Glenn, 50 ila 60 bin Morocco vatandaşının Kuzey Afrika’daki bir İspanyol toprağına geçtiğini, görüntülerde kamyonlarla yapılan hareketliliğin koordineli göründüğünü söyledi. Bazı European Union diplomatlarının bunun Morocco hükümeti tarafından organize edildiğini öne sürdüğünü aktaran Glenn, gelişmenin yalnızca bir göç meselesi olarak değil, İspanya’nın egemenliğine yönelik siyasi bir hamle olarak değerlendirilebileceğini belirtti.
+Glenn, 50 ila 60 bin Fas vatandaşının Kuzey Afrika’daki bir İspanyol toprağına geçtiğini, görüntülerde kamyonlarla yapılan hareketliliğin koordineli göründüğünü söyledi. Bazı Avrupa Birliği diplomatlarının bunun Fas hükümeti tarafından organize edildiğini öne sürdüğünü aktaran Glenn, gelişmenin yalnızca bir göç meselesi olarak değil, İspanya’nın egemenliğine yönelik siyasi bir hamle olarak değerlendirilebileceğini belirtti.
 
-Marande, Morocco ile İspanya arasındaki diğer anlaşmazlıklardan bağımsız olarak zamanlamanın önemli olduğunu savundu. Donald Trump ve Benjamin Netanyahu’nun İspanya’nın politikaları nedeniyle “bedel ödeyeceği” yönündeki açıklamalarını hatırlatan Marande, görüntülerdeki sistematik ve organize görünümün olayın kendiliğinden gelişmediği izlenimini verdiğini söyledi.
+Marande, Fas ile İspanya arasındaki diğer anlaşmazlıklardan bağımsız olarak zamanlamanın önemli olduğunu savundu. Donald Trump ve Benjamin Netanyahu’nun İspanya’nın politikaları nedeniyle “bedel ödeyeceği” yönündeki açıklamalarını hatırlatan Marande, görüntülerdeki sistematik ve organize görünümün olayın kendiliğinden gelişmediği izlenimini verdiğini söyledi.
 
 “Bunun doğal biçimde ortaya çıkmış bir gelişme olmadığını düşünüyorum,” diyen S. Muhammad Marande, “İspanya’nın Avrupa’nın geri kalanından kısmen farklı politikalar izlemesiyle yakından bağlantılı görünüyor” şeklinde değerlendirdi.
 
 Marande, İspanyol hükümetini yetersiz bulanların da bulunduğunu ancak Madrid’in İsrail’e yönelik eleştirilerinin Batı’daki İsrail yanlısı üst düzey siyasetçileri öfkelendirdiğini ileri sürdü. Ona göre, olayın İspanya’yı politikaları nedeniyle cezalandırma amacı taşıdığına geniş ölçüde inanılıyordu; ancak Marande, bu değerlendirmeyi doğrulayacak kanıta sahip olmadığını özellikle kaydetti.
 
-Glenn ise ABD Kongresi üyesi Mario Díaz-Balart’ın söz konusu İspanyol toprağının Spain değil Morocco toprağı sayılması gerektiğini savunduğunu aktardı. Díaz-Balart’ın bu görüşü, Morocco’nun “sadık bir müttefik” olduğu, İspanya’nın ise böyle davranmadığı yönündeki yorumlarla birlikte dile getirdiğini söyledi.
+Glenn ise ABD Kongresi üyesi Mario Díaz-Balart’ın söz konusu İspanyol toprağının İspanya değil Fas toprağı sayılması gerektiğini savunduğunu aktardı. Díaz-Balart’ın bu görüşü, Fas’ın “sadık bir müttefik” olduğu, İspanya’nın ise böyle davranmadığı yönündeki yorumlarla birlikte dile getirdiğini söyledi.
 
-Marande, Morocco Kralı’nın İsrail hükümetinin yakın müttefiki olduğunu ve iki ülke arasındaki askerî ilişkilerin Gazze’deki savaş sırasında da gerilmediğini belirtti. Bu nedenle Morocco’ya verilen desteğin, İspanya’yı cezalandırma ve Madrid’in İsrail politikasını değiştirme çabasının parçası olabileceğini savundu.
+Marande, Fas Kralı’nın İsrail hükümetinin yakın müttefiki olduğunu ve iki ülke arasındaki askerî ilişkilerin Gazze’deki savaş sırasında da gerilmediğini belirtti. Bu nedenle Fas’a verilen desteğin, İspanya’yı cezalandırma ve Madrid’in İsrail politikasını değiştirme çabasının parçası olabileceğini savundu.
 
-## ABD-İsrail ilişkisi ve Saudi Arabia’nın nükleer programı
+## ABD-İsrail ilişkisi ve Suudi Arabistan’ın nükleer programı
 
-Glenn, Trump’ın İspanya’nın NATO’dan çıkarılması ve ticaretinin engellenmesi gibi öneriler dile getirdiğini söyledi. Ardından Saudi Arabia ile görüşülen nükleer anlaşmayı gündeme getirerek programın Israel ile normalleşme şartına bağlandığını aktardı. Bir basın toplantısında, Saudi Arabia’ya neden İran’dan farklı davranıldığı sorusuna ABD tarafının ticari ayrıcalıkları ve müttefiklik ilişkisini gerekçe gösterdiğini belirtti.
+Glenn, Trump’ın İspanya’nın NATO’dan çıkarılması ve ticaretinin engellenmesi gibi öneriler dile getirdiğini söyledi. Ardından Suudi Arabistan ile görüşülen nükleer anlaşmayı gündeme getirerek programın İsrail ile normalleşme şartına bağlandığını aktardı. Bir basın toplantısında, Suudi Arabistan’a neden İran’dan farklı davranıldığı sorusuna ABD tarafının ticari ayrıcalıkları ve müttefiklik ilişkisini gerekçe gösterdiğini belirtti.
 
-Marande’ye göre Washington’ın yaklaşımında iki unsur vardı: “America First” anlayışı ve bunun üzerinde konumlanan İsrail’in çıkarları. ABD’nin bir anlaşmayı aylarca, hatta yıllarca müzakere ettikten sonra son aşamada Israel ile normalleşmeyi şart koştuğunu söyleyen Marande, bunun Saudi Arabia üzerindeki baskıyı artırdığını savundu.
+Marande’ye göre Washington’ın yaklaşımında iki unsur vardı: “Önce Amerika” anlayışı ve bunun üzerinde konumlanan İsrail’in çıkarları. ABD’nin bir anlaşmayı aylarca, hatta yıllarca müzakere ettikten sonra son aşamada İsrail ile normalleşmeyi şart koştuğunu söyleyen Marande, bunun Suudi Arabistan üzerindeki baskıyı artırdığını savundu.
 
-“Önce America First geliyor, fakat onun da üzerinde Israel First bulunuyor,” diyen S. Muhammad Marande, bu yaklaşımın Washington’ın hem İspanya’ya hem de West Asia’daki müttefiklerine yönelik politikasını açıklamaya yardımcı olduğunu ifade etti.
+“Önce ‘Önce Amerika’ geliyor, fakat onun da üzerinde ‘Önce İsrail’ bulunuyor,” diyen S. Muhammad Marande, bu yaklaşımın Washington’ın hem İspanya’ya hem de Batı Asya’daki müttefiklerine yönelik politikasını açıklamaya yardımcı olduğunu ifade etti.
 
-Glenn, gerileyen bir hegemonun müttefiklerine sağladığı ortak faydaları azaltıp onlardan daha fazla kaynak çıkarmaya ve onları rakiplerine karşı araç olarak kullanmaya başlayabileceğini söyledi. ABD’nin İkinci Dünya Savaşı sonrasında Europe’a daha cömert davrandığını, bugün ise sadık gördüğü ülkeleri ödüllendirip itaatsiz saydıklarını cezalandırdığını savundu.
+Glenn, gerileyen bir hegemonun müttefiklerine sağladığı ortak faydaları azaltıp onlardan daha fazla kaynak çıkarmaya ve onları rakiplerine karşı araç olarak kullanmaya başlayabileceğini söyledi. ABD’nin İkinci Dünya Savaşı sonrasında Avrupa’ya daha cömert davrandığını, bugün ise sadık gördüğü ülkeleri ödüllendirip itaatsiz saydıklarını cezalandırdığını savundu.
 
-## Qatar-Pakistan LNG tankeri ve Hürmüz Boğazı
+## Katar-Pakistan LNG tankeri ve Hürmüz Boğazı
 
-Glenn, Qatar’dan Pakistan’a giden bir LNG tankerinin İran’ın belirlediği koridoru kullandığı gerekçesiyle ABD tarafından engellendiğine ilişkin bir haberi gündeme getirdi. Marande, İran’ın Hürmüz Boğazı’ndaki gemilerin İran tarafından belirlenen güzergâhı kullanmasını istediğini söyledi.
+Glenn, Katar’dan Pakistan’a giden bir LNG tankerinin İran’ın belirlediği koridoru kullandığı gerekçesiyle ABD tarafından engellendiğine ilişkin bir haberi gündeme getirdi. Marande, İran’ın Hürmüz Boğazı’ndaki gemilerin İran tarafından belirlenen güzergâhı kullanmasını istediğini söyledi.
 
-Marande’nin anlatımına göre bu düzenleme, taraflar arasında varılan ve ayrıntıları programda açıklanmayan bir mutabakat zaptının parçasıydı. İran, mutabakat uygulanırken Hürmüz Boğazı’ndaki ticari geçişi yönetecek; ABD ise daha sonra Qatar, Saudi Arabia ve Kuwait hükümetlerinin desteğiyle ayrı bir koridor kurmaya çalışacaktı. Marande, bunun mutabakatın beşinci maddesini ihlal ettiğini ve çatışmaların yeniden başlamasına katkıda bulunduğunu öne sürdü.
+Marande’nin anlatımına göre bu düzenleme, taraflar arasında varılan ve ayrıntıları programda açıklanmayan bir mutabakat zaptının parçasıydı. İran, mutabakat uygulanırken Hürmüz Boğazı’ndaki ticari geçişi yönetecek; ABD ise daha sonra Katar, Suudi Arabistan ve Kuveyt hükümetlerinin desteğiyle ayrı bir koridor kurmaya çalışacaktı. Marande, bunun mutabakatın beşinci maddesini ihlal ettiğini ve çatışmaların yeniden başlamasına katkıda bulunduğunu öne sürdü.
 
-Qatar ile Pakistan’ın ABD’nin müttefikleri olduğunu vurgulayan Marande, tankerin yalnızca İran’ın belirlediği koridoru kullandığını ve İran’ın o aşamada gemilerden ücret almadığını belirtti. Buna rağmen geminin ABD tarafından durdurulduğunu ileri sürdü.
+Katar ile Pakistan’ın ABD’nin müttefikleri olduğunu vurgulayan Marande, tankerin yalnızca İran’ın belirlediği koridoru kullandığını ve İran’ın o aşamada gemilerden ücret almadığını belirtti. Buna rağmen geminin ABD tarafından durdurulduğunu ileri sürdü.
 
-“ABD, kendisine sadık davranmış Qatar’ı ve yakın çalıştığı Pakistan’ı cezalandırdı,” diyen S. Muhammad Marande, Washington’ın müttefiklerine karşı dahi “acımasız” davranabildiğini savundu.
+“ABD, kendisine sadık davranmış Katar’ı ve yakın çalıştığı Pakistan’ı cezalandırdı,” diyen S. Muhammad Marande, Washington’ın müttefiklerine karşı dahi “acımasız” davranabildiğini savundu.
 
-Glenn ayrıca Oman’ın İran ile Hürmüz Boğazı’nı ortaklaşa yönetme ihtimalini görüştüğünü, Trump’ın ise böyle bir anlaşma yapılması durumunda Oman’a saldırılacağını söylediğini aktardı. Bu yaklaşımın, ABD denetimi dışında gelişebilecek bölgesel düzenlemelere Washington’ın tahammül edemediğini gösterdiğini değerlendirdi.
+Glenn ayrıca Umman’ın İran ile Hürmüz Boğazı’nı ortaklaşa yönetme ihtimalini görüştüğünü, Trump’ın ise böyle bir anlaşma yapılması durumunda Umman’a saldırılacağını söylediğini aktardı. Bu yaklaşımın, ABD denetimi dışında gelişebilecek bölgesel düzenlemelere Washington’ın tahammül edemediğini gösterdiğini değerlendirdi.
 
 ## İran’a yönelik saldırı tehditleri ve olası karşılık
 
-Programın en geniş bölümü, ABD’nin İran’ın elektrik altyapısına ve kritik tesislerine büyük çaplı saldırılar düzenleyebileceği iddialarına ayrıldı. Marande, Western gazetecilere olası kitlesel hava saldırıları hakkında bilgi verildiğini ve bu nedenle söyleşinin bir gece ertelendiğini söyledi.
+Programın en geniş bölümü, ABD’nin İran’ın elektrik altyapısına ve kritik tesislerine büyük çaplı saldırılar düzenleyebileceği iddialarına ayrıldı. Marande, Batılı gazetecilere olası kitlesel hava saldırıları hakkında bilgi verildiğini ve bu nedenle söyleşinin bir gece ertelendiğini söyledi.
 
-Marande, Tehran’ın elektrik santrallerine yönelik bir saldırının günün saatine göre 14 ila 15 milyonluk bir kenti elektriksiz bırakabileceğini; hastanelerde bebeklerin ve çocukların ölümüne yol açabileceğini belirtti. İran yönetiminin tehditlere rağmen tutumunu değiştirmediğini savundu.
+Marande, Tahran’ın elektrik santrallerine yönelik bir saldırının günün saatine göre 14 ila 15 milyonluk bir kenti elektriksiz bırakabileceğini; hastanelerde bebeklerin ve çocukların ölümüne yol açabileceğini belirtti. İran yönetiminin tehditlere rağmen tutumunu değiştirmediğini savundu.
 
-“ABD saldırırsa İran savaşmaya devam eder,” diyen S. Muhammad Marande, İran’ın Kuwait, United Arab Emirates, Saudi Arabia, Bahrain ve Israel’deki hedeflere; çatışmadaki rollerine bağlı olarak Oman ve Jordan’daki hedeflere de karşılık verebileceğini açıkladı.
+“ABD saldırırsa İran savaşmaya devam eder,” diyen S. Muhammad Marande, İran’ın Kuveyt, Birleşik Arap Emirlikleri, Suudi Arabistan, Bahreyn ve İsrail’deki hedeflere; çatışmadaki rollerine bağlı olarak Umman ve Ürdün’deki hedeflere de karşılık verebileceğini açıkladı.
 
 Marande’ye göre elektrik santralleri, su arıtma tesisleri ile petrol ve doğal gaz altyapısının bölge çapında vurulması piyasalarda anında paniğe yol açabilirdi. Küresel petrol piyasasındaki arz sıkışıklığının kritik noktaya yaklaştığını ileri süren Marande, böyle bir karşılıklı saldırı dalgasının küresel ekonomik buhranı kaçınılmaz hâle getirebileceğini savundu.
 
@@ -67,46 +67,46 @@ Marande, programda “40 günlük savaş” olarak anılan çatışmanın başla
 
 ABD’nin o dönemde önleyici sistem ve füze kıtlığından söz etmediğini, buna rağmen hedeflerine ulaşamadığını savunan Marande, bugün tartışılan mühimmat eksikliklerinin doğru olması hâlinde bunun ayrıca önemli olduğunu belirtti. İran’ın “yok edileceği”, “taş devrine gönderileceği” veya “medeniyetinin silineceği” yönündeki tehditlerin Washington’ın dünya çapındaki itibarını aşındırdığını söyledi.
 
-Marande, Bill Clinton ve Barack Obama dönemlerinde ABD’nin küresel kamuoyunun önemli bir bölümü tarafından “iyi huylu hegemon” olarak görüldüğünü, kendisinin ise bu değerlendirmeye hiçbir zaman katılmadığını belirtti. Obama dönemindeki yumuşak gücün, bazı genç İranlıların çatışmaların asıl sorumlusu olarak Washington’ı değil Tehran’ı görmesini sağladığını öne sürdü.
+Marande, Bill Clinton ve Barack Obama dönemlerinde ABD’nin küresel kamuoyunun önemli bir bölümü tarafından “iyi huylu hegemon” olarak görüldüğünü, kendisinin ise bu değerlendirmeye hiçbir zaman katılmadığını belirtti. Obama dönemindeki yumuşak gücün, bazı genç İranlıların çatışmaların asıl sorumlusu olarak Washington’ı değil Tahran’ı görmesini sağladığını öne sürdü.
 
-“Trump bu yumuşak gücü tamamen yok etti,” diyen S. Muhammad Marande, Gazze, Lebanon, Syria ve İran’a yönelik politikaların ABD’nin imajındaki bozulmayı hızlandırdığını vurguladı.
+“Trump bu yumuşak gücü tamamen yok etti,” diyen S. Muhammad Marande, Gazze, Lübnan, Suriye ve İran’a yönelik politikaların ABD’nin imajındaki bozulmayı hızlandırdığını vurguladı.
 
-Marande’ye göre Israel, ABD’nin küresel etkisini korumasına yardımcı olan bir varlık değil, Washington’a ekonomik, mali ve diplomatik zarar veren bir yüktü. ABD’nin China karşısındaki gerilemesini daha kontrollü yönetebileceğini, ancak Israel’in çıkarlarını önceleyen politikaların bunu engellediğini savundu.
+Marande’ye göre İsrail, ABD’nin küresel etkisini korumasına yardımcı olan bir varlık değil, Washington’a ekonomik, mali ve diplomatik zarar veren bir yüktü. ABD’nin Çin karşısındaki gerilemesini daha kontrollü yönetebileceğini, ancak İsrail’in çıkarlarını önceleyen politikaların bunu engellediğini savundu.
 
-## Europe ve East Asia’daki müttefiklerin durumu
+## Avrupa ve Doğu Asya’daki müttefiklerin durumu
 
 Glenn, ABD’nin siyasi liderleri kendisine uyum göstermeye zorlayabildiğini ancak toplumlarda Washington’a yönelik şüpheciliğin büyüdüğünü söyledi. İspanyol, Alman ve diğer Avrupalı liderlerin Trump’ın tehditleri karşısında sessiz kalmasını, siyasi sınıfların ABD’yi yatıştırmayı ulusal çıkar ve saygınlığın önüne koymasının örneği olarak sundu.
 
-Marande, ABD ile birlikte hareket eden ülkelerin Washington’ın gerileyişinden zarar gördüğünü savundu. Europe’un İran, Russia ve China’ya yönelik politikalar nedeniyle ABD’den daha hızlı zayıfladığını ileri sürdü. East Asia’da ise South Korea’nın siyasi ve mali bedelini üstlenerek aldığı füze sistemlerinin daha sonra Israel’e gönderildiğini iddia etti.
+Marande, ABD ile birlikte hareket eden ülkelerin Washington’ın gerileyişinden zarar gördüğünü savundu. Avrupa’nın İran, Rusya ve Çin’e yönelik politikalar nedeniyle ABD’den daha hızlı zayıfladığını ileri sürdü. Doğu Asya’da ise Güney Kore’nin siyasi ve mali bedelini üstlenerek aldığı füze sistemlerinin daha sonra İsrail’e gönderildiğini iddia etti.
 
-“İmparatorluğun yanında kalırsanız onunla birlikte aşağı gidersiniz,” diyen S. Muhammad Marande, ABD’nin çip üretimi ve sanayi politikalarının da South Korea ile Avrupa ülkelerinin çıkarlarını dikkate almadığını ifade etti.
+“İmparatorluğun yanında kalırsanız onunla birlikte aşağı gidersiniz,” diyen S. Muhammad Marande, ABD’nin çip üretimi ve sanayi politikalarının da Güney Kore ile Avrupa ülkelerinin çıkarlarını dikkate almadığını ifade etti.
 
-## Jordan’daki hoşnutsuzluk ve bölgesel yönetimlerin kırılganlığı
+## Ürdün’deki hoşnutsuzluk ve bölgesel yönetimlerin kırılganlığı
 
-Glenn, yüzlerce Jordanlı siyasetçi ve kamuya mal olmuş kişinin ülkedeki ABD askerlerinin çıkarılması çağrısında bulunan açık mektubunu gündeme getirdi. ABD askerî varlığının Jordan’a güvenlik değil yıkım getirdiğini savunan bu kişilerin, hükümetten Washington ile arasına mesafe koymasını istediğini aktardı.
+Glenn, yüzlerce Ürdünlü siyasetçi ve kamuya mal olmuş kişinin ülkedeki ABD askerlerinin çıkarılması çağrısında bulunan açık mektubunu gündeme getirdi. ABD askerî varlığının Ürdün’e güvenlik değil yıkım getirdiğini savunan bu kişilerin, hükümetten Washington ile arasına mesafe koymasını istediğini aktardı.
 
-Marande, West Asia ve North Africa’daki ABD müttefiki hükümetlerin giderek daha ağır iç baskılarla karşılaşacağını öne sürdü. Bu yönetimleri otoriter “polis devletleri” olarak tanımladı ve iktidarlarını korumak için Batılı istihbarat kurumlarından destek aldıklarını savundu.
+Marande, Batı Asya ve Kuzey Afrika’daki ABD müttefiki hükümetlerin giderek daha ağır iç baskılarla karşılaşacağını öne sürdü. Bu yönetimleri otoriter “polis devletleri” olarak tanımladı ve iktidarlarını korumak için Batılı istihbarat kurumlarından destek aldıklarını savundu.
 
-Arab Spring (Arap Baharı) öncesinde de yüzeyde düzen görünmesine rağmen yönetimlerin kırılgan olduğunun kısa sürede ortaya çıktığını belirten Marande, günümüzdeki durumun daha hassas olduğunu söyledi. Qatar, Saudi Arabia ve United Arab Emirates merkezli büyük medya ağlarının ABD ve daha geniş Batı çıkarlarıyla uyumlu yayın yaptığını; buna rağmen yorumlarda İran ve “direniş” yanlısı görüşlerin ağır bastığını ileri sürdü.
+Arap Baharı öncesinde de yüzeyde düzen görünmesine rağmen yönetimlerin kırılgan olduğunun kısa sürede ortaya çıktığını belirten Marande, günümüzdeki durumun daha hassas olduğunu söyledi. Katar, Suudi Arabistan ve Birleşik Arap Emirlikleri merkezli büyük medya ağlarının ABD ve daha geniş Batı çıkarlarıyla uyumlu yayın yaptığını; buna rağmen yorumlarda İran ve “direniş” yanlısı görüşlerin ağır bastığını ileri sürdü.
 
-“Yüzeyde her şey normal görünebilir, fakat altında çok sayıda gelişme yaşanıyor,” diyen S. Muhammad Marande, Jordan’daki açık itirazların hükümet açısından ciddi bir uyarı olduğunu belirtti.
+“Yüzeyde her şey normal görünebilir, fakat altında çok sayıda gelişme yaşanıyor,” diyen S. Muhammad Marande, Ürdün’deki açık itirazların hükümet açısından ciddi bir uyarı olduğunu belirtti.
 
-## Jordan’daki ABD hedeflerine İran saldırısı
+## Ürdün’deki ABD hedeflerine İran saldırısı
 
-Glenn, İran’ın Jordan’daki ABD üslerine saldırmasının Trump’ın İran’ın elektrik altyapısını vurma tehdidini sertleştirdiğini söyledi. Trump’ın saldırıyı müzakereler sürerken yapılmış beklenmedik bir eylem olarak sunduğunu, ancak taraflar arasında ciddi bir ateşkes bulunduğunun açık olmadığını ifade etti.
+Glenn, İran’ın Ürdün’deki ABD üslerine saldırmasının Trump’ın İran’ın elektrik altyapısını vurma tehdidini sertleştirdiğini söyledi. Trump’ın saldırıyı müzakereler sürerken yapılmış beklenmedik bir eylem olarak sunduğunu, ancak taraflar arasında ciddi bir ateşkes bulunduğunun açık olmadığını ifade etti.
 
 Marande, ABD’nin İran’a karşı savaşı yeniden başlattığını, yükümlülüklerini ihlal ettiğini ve İran limanlarıyla Hürmüz Boğazı üzerinde kuşatma uyguladığını iddia etti. Bu nedenle resmî bir ateşkes bulunmadığını ve Washington’ın savaşın ne zaman başlayıp duracağına tek başına karar veremeyeceğini savundu.
 
 “ABD ateşkesin ne zaman başlayacağını ve savaşın ne zaman yeniden açılacağını dikte edemez,” diyen S. Muhammad Marande, “İran gerekli gördüğü anda saldırma hakkına sahip olduğunu açıkça ortaya koydu” şeklinde konuştu.
 
-Marande’ye göre ABD’nin Jordan’da asker ve teçhizat toplaması İran tarafından tehdit olarak algılandı. İran’ın iki saldırısı, ABD’nin olası bir hava harekâtında ihtiyaç duyacağı önemli varlıkları devre dışı bıraktı ve Tehran’ın yeni bir saldırıyı beklemeden inisiyatif alabileceği mesajını verdi.
+Marande’ye göre ABD’nin Ürdün’de asker ve teçhizat toplaması İran tarafından tehdit olarak algılandı. İran’ın iki saldırısı, ABD’nin olası bir hava harekâtında ihtiyaç duyacağı önemli varlıkları devre dışı bıraktı ve Tahran’ın yeni bir saldırıyı beklemeden inisiyatif alabileceği mesajını verdi.
 
-## Yemen, Saudi Arabia ve Iraq hattındaki tırmanma
+## Yemen, Suudi Arabistan ve Irak hattındaki tırmanma
 
-Söyleşinin sonunda Marande, Yemen havaalanına yönelik saldırının Yemen güçlerinin Saudi Arabia’ya karşılık vermesine yol açtığını söyledi. Yemen tarafının kadınlar ve çocuklar üzerindeki kuşatmayı artık kabul etmeyeceğini bildirerek Saudi Arabia’ya karşı bir “karşı kuşatma” başlattığını aktardı.
+Söyleşinin sonunda Marande, Yemen havaalanına yönelik saldırının Yemen güçlerinin Suudi Arabistan’a karşılık vermesine yol açtığını söyledi. Yemen tarafının kadınlar ve çocuklar üzerindeki kuşatmayı artık kabul etmeyeceğini bildirerek Suudi Arabistan’a karşı bir “karşı kuşatma” başlattığını aktardı.
 
-Marande, Hürmüz Boğazı’ndaki çatışma nedeniyle Persian Gulf çıkışının risk altında olduğu bir dönemde Saudi Arabia’nın Red Sea güzergâhına ihtiyaç duyduğunu belirtti. Buna rağmen Yemen’i kışkırtmasının ters teptiğini ve bazı kişilerin bu politikanın ABD teşvikiyle yürütüldüğünü düşündüğünü söyledi.
+Marande, Hürmüz Boğazı’ndaki çatışma nedeniyle Basra Körfezi çıkışının risk altında olduğu bir dönemde Suudi Arabistan’ın Kızıldeniz güzergâhına ihtiyaç duyduğunu belirtti. Buna rağmen Yemen’i kışkırtmasının ters teptiğini ve bazı kişilerin bu politikanın ABD teşvikiyle yürütüldüğünü düşündüğünü söyledi.
 
-Yemen güçlerinin Saudi petrol tesislerine saldırıyı üstlendiğini belirten Marande, Riyadh’ın yeni enerji saldırılarından çekindiği için Yemen yerine Iraq’ı bombaladığını ve çok sayıda insanı öldürdüğünü iddia etti. Bunun Iraq genelinde öfke yarattığını aktardı.
+Yemen güçlerinin Suudi petrol tesislerine saldırıyı üstlendiğini belirten Marande, Riyad’ın yeni enerji saldırılarından çekindiği için Yemen yerine Irak’ı bombaladığını ve çok sayıda insanı öldürdüğünü iddia etti. Bunun Irak genelinde öfke yarattığını aktardı.
 
 Glenn, ABD’nin geçmişte sınırlı saldırılar düzenleyip karşı tarafın misillemeden kaçınmasını beklediğini söyledi. Bu “okul bahçesi zorbalığı” yaklaşımının, hedef alınan ülkeler karşılık vermeye başladıkça işlemez hâle geldiğini savundu. Ona göre Washington ve Avrupa başkentlerinin tek kutuplu dönemin sona erdiğini kabul etmemesi, daha geniş savaşlara yol açabilecek yanlış hesaplama riskini büyütüyordu.

--- a/pipeline/prompts/translate.md
+++ b/pipeline/prompts/translate.md
@@ -20,7 +20,8 @@ Write a 1500-2000 word Turkish article faithfully reporting what was discussed i
 - Where a speaker makes a specific factual claim or cites a number/statistic, include it exactly.
 - Section headers (`##`) should reflect the actual topics discussed, in order.
 - Opening paragraph: who spoke, what the episode was about, and why it matters, in 2-3 sentences.
-- Keep proper nouns in English. Add Turkish explanation in parentheses on first mention if unfamiliar, for example "Supreme Court (Yüksek Mahkeme)".
+- Keep personal names and brand names in their original spelling.
+- Always use established Turkish names for countries, cities, regions, continents, seas, gulfs, nationalities, international institutions, and other political or geographic entities. This rule applies consistently to the title, opening description, tags, section headers, article body, quotes, and thread. Examples: "West Asia" → "Batı Asya", "Middle East" → "Orta Doğu", "Morocco" → "Fas", "Saudi Arabia" → "Suudi Arabistan", "Jordan" → "Ürdün", "Qatar" → "Katar", "Israel" → "İsrail", "Russia" → "Rusya", "China" → "Çin", "European Union" → "Avrupa Birliği", "South Korea" → "Güney Kore", "Persian Gulf" → "Basra Körfezi", "Red Sea" → "Kızıldeniz", and "Tehran" → "Tahran". Preserve established abbreviations such as NATO. For an unfamiliar institution without an established Turkish name, keep the original name and add a Turkish explanation in parentheses on first mention, for example "Supreme Court (Yüksek Mahkeme)".
 - Use established Turkish equivalents for political terms:
   - "Republican Party" → "Cumhuriyetçi Parti"
   - "Democratic Party" → "Demokrat Parti"
@@ -33,6 +34,7 @@ Write a 1500-2000 word Turkish article faithfully reporting what was discussed i
   - "swing state" → "kararsız eyalet"
   - "primary" → "ön seçim"
 - For idioms, translate the meaning, for example "kicked the can down the road" → "sorunu erteledi".
+- Before returning the result, perform a terminology consistency check: ensure no English country, city, region, continent, sea/gulf, nationality, or international-institution name remains when an established Turkish equivalent exists, and use the same Turkish term in every output section.
 
 ---TITLE---
 A concise, compelling Turkish title for this article in newspaper headline style. Always include the full name of the main speaker/guest in the title, not just their title or role. Example: "Eski MI6 Yetkilisi Shashank Joshi: ..." not just "Eski MI6 Yetkilisi: ..."


### PR DESCRIPTION
## Summary
- Bildirilen S. Muhammad Marande yazısındaki İngilizce ülke ve bölge adlarını yerleşik Türkçe karşılıklarıyla değiştirir
- Çeviri promptunda kişi/marka adlarını coğrafi ve siyasi adlardan ayırır
- Tüm çıktı bölümleri için Türkçe terminoloji tutarlılığı kontrolü ekler

Closes #66

## Test plan
- Sentetik transkript prompt doğrulaması: İngilizce coğrafi ad kalmadı
- `cd pipeline && npx tsc --noEmit`
- `cd blog && npx astro build`
- Makale terminoloji assertion taraması
- `git diff --check`